### PR TITLE
doc: rewrite README — concise vision-first format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,55 @@
 # KAPE — Kubernetes Agentic Platform Execution
 
-KAPE is a Kubernetes-native, event-driven AI agent platform that enables autonomous cluster monitoring, decision-making, and remediation.
+> Autonomous cluster monitoring, reasoning, and remediation — declared entirely in Kubernetes CRDs.
 
-Engineers declare agent behaviour entirely through Kubernetes Custom Resources — no code changes required to extend the system.
+![License](https://img.shields.io/badge/license-Apache%202.0-blue)
+![Go](https://img.shields.io/badge/go-1.23-00ADD8)
+![Python](https://img.shields.io/badge/python-3.12-3776AB)
 
-## Overview
+## Why KAPE?
 
-Modern Kubernetes clusters generate enormous volumes of signals: security violations, resource pressure, policy breaches, cost anomalies, and runtime anomalies. Existing tooling either acts without reasoning (autoscalers, Kyverno) or reasons without acting (K8sGPT). KAPE bridges the gap by combining:
+Kubernetes clusters generate constant signal — security violations, resource pressure, policy breaches, cost anomalies.
+Existing tools either **act without reasoning** (autoscalers, Kyverno) or **reason without acting** (K8sGPT).
+KAPE does both.
 
-- **Event-driven signal collection** from Cilium, Kyverno, Falco, Karpenter, K8s Audit
-- **LLM-powered contextual reasoning** via LangGraph ReAct agents
-- **Declarative CRD-based configuration** under `kape.io/v1alpha1`
-- **Extensible tool execution** via MCP servers consumed through `KapeTool` CRDs
+- **Event-driven** — ingests signals from Falco, Cilium, Kyverno, Karpenter, and K8s Audit via CloudEvents
+- **LLM-powered reasoning** — LangGraph ReAct agents analyse context and produce structured decisions
+- **Declarative config** — define agent behaviour entirely through `KapeHandler`, `KapeTool`, and `KapeSchema` CRDs — no code changes required
+- **Scales to zero** — KEDA drives handler pods from NATS consumer lag; idle agents cost nothing
 
-## How It Works
+## Quick Start
 
-1. **Event producers** (Falco, Kyverno, Cilium, Karpenter, K8s Audit) emit CloudEvents to NATS JetStream via CloudEvents adapters.
-2. The **Kape Operator** watches `KapeHandler` CRDs and provisions handler Deployments + KEDA ScaledObjects.
-3. Each **handler pod** runs a LangGraph ReAct agent that:
-   - Consumes the event from NATS
-   - Self-enriches context by calling MCP tools during its reasoning loop
-   - Produces a structured decision conforming to a declared `KapeSchema`
-   - Executes deterministic post-decision actions (emit downstream events, persist audit record)
-4. Handler pods **scale independently** via KEDA on NATS consumer lag.
-5. All decisions are persisted as **Task records** via `kape-task-service`, powering the management dashboard.
+```bash
+helm install kape ./helm/kape --namespace kape-system --create-namespace
+```
 
-## CRDs
+Then declare your first agent:
 
-| CRD | Responsibility |
-|-----|---------------|
-| `KapeHandler` | One complete agent pipeline — LLM config, tools, schema ref, scaling, retry policy |
-| `KapeTool` | Tool capability registration (`mcp`, `memory`, `event-publish`) |
-| `KapeSchema` | Structured output contract for LLM decisions |
-| `KapePolicy` | (v2) Cross-handler guardrails |
+```yaml
+apiVersion: kape.io/v1alpha1
+kind: KapeHandler
+metadata:
+  name: falco-responder
+spec:
+  source: falco
+  llm:
+    model: gpt-4o
+  tools:
+    - name: kubectl-readonly
+  schemaRef: incident-triage-v1
+```
 
-## Implementation Stack
+→ [Full getting-started guide](docs/)
 
-| Layer | Technology |
-|-------|-----------|
-| API group | `kape.io/v1alpha1` |
-| Namespace | `kape-system` |
-| Handler runtime | Python + LangGraph |
-| LLM SDK | LangChain (`bind_tools`, `with_structured_output`) |
-| MCP adapter | `langchain-mcp-adapters` (MCPToolkit) |
-| Memory backend | Qdrant (primary) |
-| Event broker | NATS JetStream |
-| Scaling | KEDA (NatsJetStream scaler) |
-| Observability | OTEL → Arize OpenInference, Prometheus |
-| Operator | Go + controller-runtime |
+## Documentation
 
-## Design Specs
-
-| Document | Description |
-|----------|-------------|
-| [`specs/0001-rfc`](specs/0001-rfc/README.md) | Master RFC — full platform design |
-| [`specs/0002-crds-design`](specs/0002-crds-design/README.md) | CRD schema reference |
-| [`specs/0003-q&a`](specs/0003-q&a/README.md) | Open questions resolution |
-| [`specs/0004-kape-handler`](specs/0004-kape-handler/README.md) | Handler pod technical design |
-| [`specs/0005-kape-operator`](specs/0005-kape-operator/README.md) | Kape Operator technical design |
-| [`specs/0006-events-broker-design`](specs/0006-events-broker-design/README.md) | Event broker and adapter design |
-| [`specs/0007-security-layer`](specs/0007-security-layer/README.md) | Security hardening specifications |
-| [`specs/plan.md`](specs/plan.md) | Session-by-session discussion plan |
-
-## Security Model
-
-KAPE enforces security at every layer:
-- MCP RBAC templates per tool type
-- `KapeTool` allow/deny filtering — LLM never sees filtered tools
-- Prompt injection defence via system prompt templates and input escaping
-- Cilium NetworkPolicy restricting handler pod egress
-- CEL validation on all CRD fields
-- ESO-managed secrets for LLM API keys and MCP credentials
-- Append-only audit log
+| | |
+|---|---|
+| [Architecture](docs/architecture.md) | How the platform fits together |
+| [CRD Reference](docs/crds.md) | KapeHandler, KapeTool, KapeSchema fields |
+| [Design Specs](specs/) | RFCs and detailed technical decisions |
+| [Contributing](CONTRIBUTING.md) | Development setup and workflow |
 
 ## Status
 
-This repository contains design specifications. Implementation is in planning (see [`specs/plan.md`](specs/plan.md) for the session index and progress).
+Early development — core operator, runtime, and adapters are functional. Dashboard and task-service in progress.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ spec:
 |---|---|
 | [Architecture](docs/architecture.md) | How the platform fits together |
 | [CRD Reference](docs/crds.md) | KapeHandler, KapeTool, KapeSchema fields |
-| [Design Specs](specs/) | RFCs and detailed technical decisions |
+| [Design Specs](docs/specs/) | RFCs and detailed technical decisions |
 | [Contributing](CONTRIBUTING.md) | Development setup and workflow |
 
 ## Status

--- a/docs/superpowers/plans/2026-04-19-readme-redesign.md
+++ b/docs/superpowers/plans/2026-04-19-readme-redesign.md
@@ -1,0 +1,116 @@
+# README Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the verbose reference README with a concise, vision-first README in SigNoz style.
+
+**Architecture:** Single file replacement — `README.md` at repo root. No other files touched.
+
+**Tech Stack:** Markdown only.
+
+---
+
+### Task 1: Replace README.md
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Overwrite README.md with the new content**
+
+Replace the entire contents of `/home/tony/projects/kape-io/README.md` with:
+
+```markdown
+# KAPE — Kubernetes Agentic Platform Execution
+
+> Autonomous cluster monitoring, reasoning, and remediation — declared entirely in Kubernetes CRDs.
+
+![License](https://img.shields.io/badge/license-Apache%202.0-blue)
+![Go](https://img.shields.io/badge/go-1.23-00ADD8)
+![Python](https://img.shields.io/badge/python-3.12-3776AB)
+
+## Why KAPE?
+
+Kubernetes clusters generate constant signal — security violations, resource pressure, policy breaches, cost anomalies.
+Existing tools either **act without reasoning** (autoscalers, Kyverno) or **reason without acting** (K8sGPT).
+KAPE does both.
+
+- **Event-driven** — ingests signals from Falco, Cilium, Kyverno, Karpenter, and K8s Audit via CloudEvents
+- **LLM-powered reasoning** — LangGraph ReAct agents analyse context and produce structured decisions
+- **Declarative config** — define agent behaviour entirely through `KapeHandler`, `KapeTool`, and `KapeSchema` CRDs — no code changes required
+- **Scales to zero** — KEDA drives handler pods from NATS consumer lag; idle agents cost nothing
+
+## Quick Start
+
+```bash
+helm install kape ./helm/kape --namespace kape-system --create-namespace
+```
+
+Then declare your first agent:
+
+```yaml
+apiVersion: kape.io/v1alpha1
+kind: KapeHandler
+metadata:
+  name: falco-responder
+spec:
+  source: falco
+  llm:
+    model: gpt-4o
+  tools:
+    - name: kubectl-readonly
+  schemaRef: incident-triage-v1
+```
+
+→ [Full getting-started guide](docs/)
+
+## Documentation
+
+| | |
+|---|---|
+| [Architecture](docs/architecture.md) | How the platform fits together |
+| [CRD Reference](docs/crds.md) | KapeHandler, KapeTool, KapeSchema fields |
+| [Design Specs](specs/) | RFCs and detailed technical decisions |
+| [Contributing](CONTRIBUTING.md) | Development setup and workflow |
+
+## Status
+
+Early development — core operator, runtime, and adapters are functional. Dashboard and task-service in progress.
+```
+
+- [ ] **Step 2: Verify the file looks correct**
+
+```bash
+cat README.md
+```
+
+Expected: clean markdown, ~60 lines, no old content remaining.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "doc: rewrite README — concise vision-first format"
+```
+
+- [ ] **Step 4: Push branch and open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "doc: rewrite README — concise vision-first format" --body "$(cat <<'EOF'
+## Summary
+
+- Replaces verbose reference README with a concise SigNoz-style README
+- Leads with a differentiator pitch (vs autoscalers / K8sGPT)
+- Adds quick-start helm + KapeHandler YAML snippet
+- Adds docs navigation table
+- Honest one-line status at the bottom
+
+## Test plan
+
+- [ ] Render README on GitHub and verify formatting
+- [ ] Check all section headings are present: Why KAPE, Quick Start, Documentation, Status
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-19-readme-redesign.md
+++ b/docs/superpowers/specs/2026-04-19-readme-redesign.md
@@ -1,0 +1,68 @@
+---
+title: README Redesign
+date: 2026-04-19
+status: approved
+---
+
+# README Redesign Spec
+
+## Goal
+
+Replace the current detailed-reference README with a professional, concise README in the style of SigNoz — vision-first, audience: both external GitHub visitors and internal team.
+
+## Audience
+
+Both engineers browsing GitHub who might use/contribute to KAPE, and internal collaborators who already know the project.
+
+## Tone & Style
+
+SigNoz-style: short hero pitch, "why us" differentiator bullets, quick-start code block, docs navigation links, honest status line at the bottom.
+
+## Structure
+
+### 1. Hero Block (~10 lines)
+
+- `# KAPE — Kubernetes Agentic Platform Execution` heading
+- One-line tagline: _Autonomous cluster monitoring, reasoning, and remediation — declared entirely in Kubernetes CRDs._
+- Three inline badges: License (Apache 2.0), Go version, Python version
+
+### 2. Why KAPE? (~8 lines)
+
+- Two-sentence framing: existing tools either act without reasoning (autoscalers, Kyverno) or reason without acting (K8sGPT); KAPE does both.
+- Four differentiator bullets, each bold-keyed:
+  - **Event-driven** — Falco, Cilium, Kyverno, Karpenter, K8s Audit via CloudEvents
+  - **LLM-powered reasoning** — LangGraph ReAct agents, structured decisions
+  - **Declarative config** — KapeHandler, KapeTool, KapeSchema CRDs; no code changes
+  - **Scales to zero** — KEDA on NATS consumer lag
+
+### 3. Quick Start (~15 lines)
+
+- `helm install` one-liner
+- Minimal `KapeHandler` YAML snippet showing the real API shape
+- Link to full getting-started guide in `docs/`
+
+### 4. Documentation Table (~8 lines)
+
+Two-column table linking to:
+- Architecture
+- CRD Reference
+- Design Specs (`specs/`)
+- Contributing
+
+### 5. Status (~2 lines)
+
+One honest sentence: core operator, runtime, and adapters are functional; dashboard and task-service in progress.
+
+## What Is Removed
+
+- Verbose "How It Works" numbered list
+- Full implementation stack table
+- Full CRD responsibility table
+- Design specs table (moved to Documentation section as a single link)
+- Security model section (moves to dedicated doc)
+
+## Constraints
+
+- No logo or screenshot placeholder (not yet available)
+- Badge URLs to be filled in once repo is public / CI is configured
+- `docs/architecture.md`, `docs/crds.md`, `CONTRIBUTING.md` are linked but not yet written — that is acceptable; links serve as signposts


### PR DESCRIPTION
## Summary

- Replaces verbose reference README with a concise SigNoz-style README (~60 lines vs ~80)
- Leads with a differentiator pitch (vs autoscalers / K8sGPT)
- Adds quick-start `helm install` + `KapeHandler` YAML snippet
- Adds docs navigation table
- Fixes Design Specs link to `docs/specs/` (moved from root `specs/`)
- Honest one-line status at the bottom

## Test plan

- [ ] Render README on GitHub and verify formatting
- [ ] Check all section headings are present: Why KAPE, Quick Start, Documentation, Status
- [ ] Verify Design Specs link resolves to `docs/specs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)