### PR TITLE
doc: sync roadmap phase 6 status

### DIFF
--- a/docs/roadmap/phases.md
+++ b/docs/roadmap/phases.md
@@ -7,7 +7,7 @@
 | 3  | Task Service             | done       | —  | 0008, 0009       | [phases/03-task-service.md](phases/03-task-service.md) |
 | 4  | Minimal Runtime          | done       | —  | 0001, 0004       | [phases/04-minimal-runtime.md](phases/04-minimal-runtime.md) |
 | 5  | AlertManager Adapter     | done       | M1 | 0006             | [phases/05-alertmanager-adapter.md](phases/05-alertmanager-adapter.md) |
-| 6  | Full Operator            | pending    | M2 | 0002, 0005, 0013 | [phases/06-full-operator.md](phases/06-full-operator.md) |
+| 6  | Full Operator            | in_progress | M2 | 0002, 0005, 0013 | [phases/06-full-operator.md](phases/06-full-operator.md) |
 | 7  | Full Runtime             | pending    | M3 | 0004, 0006, 0013 | [phases/07-full-runtime.md](phases/07-full-runtime.md) |
 | 8  | K8s Audit + Security     | pending    | M4 | 0006, 0007       | [phases/08-audit-security.md](phases/08-audit-security.md) |
 | 9  | Dashboard                | pending    | M5 | 0009, 0008       | [phases/09-dashboard.md](phases/09-dashboard.md) |

--- a/docs/roadmap/phases/06-full-operator/README.md
+++ b/docs/roadmap/phases/06-full-operator/README.md
@@ -1,6 +1,6 @@
 # Phase 6 — Full Operator
 
-**Status:** pending
+**Status:** in_progress
 **Milestone:** M2
 **Specs:** 0002, 0005, 0013
 **Modified by:** 0012 (created), 0013 (KapeSkillReconciler, KapeProxyReconciler, kapeproxy sidecar model added)
@@ -16,6 +16,9 @@ The operator manages the full resource lifecycle — KapeTool (memory + mcp type
 - `0013-kape-skill-crd` — KapeSkillReconciler, KapeHandlerReconciler changes, kapeproxy sidecar model, kapeproxy-config rendering
 
 ## Work
+
+> **Shipped (cc72771 / PR #7):** KapeToolReconciler, KapeSchemaReconciler, KapeHandlerReconciler (12-step), Qdrant StatefulSet provisioning, KEDA ScaledObject, per-tool sidecar injection.
+> **Still pending:** KapeSkillReconciler, KapeProxyReconciler, kapeproxy binary (`cmd/kapeproxy/`), webhook admission, `operator/infra/qdrant/` collection management, kapeproxy sidecar model.
 
 ### KapeTool reconciler — memory type
 - Provision Qdrant StatefulSet + Service in `kape-system`


### PR DESCRIPTION
## Summary
- Mark phase 6 (Full Operator) as `in_progress` — KapeToolReconciler, KapeSchemaReconciler, KapeHandlerReconciler (12-step), Qdrant StatefulSet, and KEDA ScaledObject are shipped; KapeSkillReconciler, KapeProxyReconciler, kapeproxy binary, and webhook still pending.

## Evidence
- `operator/controller/reconcile/schema.go` (KapeSchemaReconciler)
- `operator/controller/reconcile/tool.go` (KapeToolReconciler)
- `operator/controller/reconcile/handler.go` (12-step KapeHandlerReconciler)
- `operator/infra/k8s/scaledobject.go` (KEDA ScaledObject)
- `operator/infra/k8s/statefulset.go` (Qdrant StatefulSet provisioning)
- cc72771 — Merge pull request #7 from dzungtr/feature/phase6-full-operator (44 files, 6882 insertions)
- `operator/infra/qdrant/` — only `.gitkeep` (collection management not shipped)
- `operator/controller/webhook/` — only `.gitkeep` (webhook not shipped)
- No `cmd/kapeproxy/` binary, no `operator/controller/reconcile/skill.go`

## Test plan
- [ ] Phase status matches code state
- [ ] No code changes (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)