### PR TITLE
feat(runtime): add ProxyConfig section (Phase 7.1)

### DIFF
--- a/runtime/settings.toml
+++ b/runtime/settings.toml
@@ -34,6 +34,14 @@ endpoint = "http://localhost:8080"
 endpoint = "http://localhost:4318"
 service_name = "kape-handler"
 
+[proxy]
+endpoint  = "http://localhost:8080"
+transport = "sse"
+
+[tools.order-memory]
+type            = "memory"
+qdrant_endpoint = "http://kape-memory-order-memory.kape-system:6333"
+
 [schema]
 name = "test-schema"
 

--- a/runtime/src/kape_runtime/config.py
+++ b/runtime/src/kape_runtime/config.py
@@ -46,6 +46,12 @@ class OtelConfig:
 
 
 @dataclass
+class ProxyConfig:
+    endpoint: str
+    transport: str
+
+
+@dataclass
 class SchemaConfig:
     name: str
     json_schema: dict[str, Any]
@@ -58,6 +64,7 @@ class Config:
     nats: NatsConfig
     task_service: TaskServiceConfig
     otel: OtelConfig
+    proxy: ProxyConfig
     schema: SchemaConfig
 
 
@@ -112,6 +119,10 @@ def load_config(settings_file: str | None = None) -> Config:
         otel=OtelConfig(
             endpoint=raw.otel.endpoint,
             service_name=raw.otel.service_name,
+        ),
+        proxy=ProxyConfig(
+            endpoint=raw.proxy.endpoint,
+            transport=raw.proxy.transport,
         ),
         schema=SchemaConfig(
             name=raw.schema.name,

--- a/runtime/tests/test_config.py
+++ b/runtime/tests/test_config.py
@@ -36,6 +36,10 @@ endpoint = "http://localhost:8080"
 endpoint = "http://localhost:4318"
 service_name = "kape-handler"
 
+[proxy]
+endpoint = "http://localhost:8080"
+transport = "sse"
+
 [schema]
 name = "test-schema"
 
@@ -64,6 +68,8 @@ type = "string"
     assert config.nats.stream == "KAPE_EVENTS"
     assert config.task_service.endpoint == "http://localhost:8080"
     assert config.otel.endpoint == "http://localhost:4318"
+    assert config.proxy.endpoint == "http://localhost:8080"
+    assert config.proxy.transport == "sse"
     assert config.schema.name == "test-schema"
     assert config.schema.json_schema["type"] == "object"
     assert "decision" in config.schema.json_schema["required"]
@@ -99,6 +105,10 @@ endpoint = "http://localhost:8080"
 [otel]
 endpoint = "http://localhost:4318"
 service_name = "kape-handler"
+
+[proxy]
+endpoint = "http://localhost:8080"
+transport = "sse"
 
 [schema]
 name = "test-schema"


### PR DESCRIPTION
## Summary

Phase 7.1 — Proxy Config. Introduces a single `[proxy]` section in `settings.toml` with `endpoint` and `transport` fields, accessible via `Config.proxy: ProxyConfig`. Memory-type tools keep their own `[tools.<name>]` section (an example `[tools.order-memory]` block is included for documentation; full memory wiring lands in Phase 7.4).

- New `ProxyConfig` dataclass and `proxy` field on `Config`
- `load_config()` reads `[proxy]` from settings TOML
- Example dev `settings.toml` now includes `[proxy]` and `[tools.order-memory]` blocks
- Tests assert `config.proxy.endpoint` and `config.proxy.transport` round-trip

Spec: `docs/roadmap/phases/07-full-runtime/01-proxy-config.md`

## Test plan

- [x] `conda run -n kape-runtime pytest runtime/tests/test_config.py -v` — 2 passed
- [x] Full runtime suite: `pytest runtime/tests/ -v` — 31 passed
- [x] Sanity-loaded `runtime/settings.toml` and confirmed `proxy.endpoint`/`proxy.transport` populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)