### PR TITLE
feat(runtime): Phase 7.5 — Actions Router (event-publish, webhook, save_memory)

### DIFF
--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "httpx>=0.27.0",
     "python-ulid>=3.0.0",
     "mcp>=1.3.0",
+    "jsonpath-ng>=1.6.0",
+    "qdrant-client>=1.12.0",
 ]
 
 [project.scripts]

--- a/runtime/src/kape_runtime/actions/__init__.py
+++ b/runtime/src/kape_runtime/actions/__init__.py
@@ -1,0 +1,6 @@
+from kape_runtime.actions.event_emitter import emit_event
+from kape_runtime.actions.router import run_actions
+from kape_runtime.actions.save_memory import save_memory
+from kape_runtime.actions.webhook import post_webhook
+
+__all__ = ["emit_event", "post_webhook", "run_actions", "save_memory"]

--- a/runtime/src/kape_runtime/actions/event_emitter.py
+++ b/runtime/src/kape_runtime/actions/event_emitter.py
@@ -1,0 +1,58 @@
+# runtime/src/kape_runtime/actions/event_emitter.py
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from jinja2 import Environment
+
+_PROMPT_MARKER = "$prompt"
+# Templates render JSON event payloads, not HTML — autoescape would corrupt JSON
+# strings containing &, <, >, ', or ". Action configs come from operator-controlled
+# KapeHandler CRDs, not untrusted input.
+_jinja = Environment(autoescape=False)  # noqa: S701
+
+
+def _render(value: Any, ctx: dict[str, Any]) -> Any:
+    """Recursively render Jinja2 strings; preserve `$prompt` marker verbatim."""
+    if isinstance(value, str):
+        if value == _PROMPT_MARKER:
+            return _PROMPT_MARKER
+        return _jinja.from_string(value).render(ctx)
+    if isinstance(value, dict):
+        return {k: _render(v, ctx) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_render(v, ctx) for v in value]
+    return value
+
+
+async def emit_event(
+    action: dict[str, Any],
+    schema_output: dict[str, Any],
+    parent_task_id: str,
+    nats_client: Any,
+) -> None:
+    """Build a CloudEvent from the action config and publish it to NATS."""
+    subject: str = action["subject"]
+    event_type: str = action.get("event_type") or action.get("type_field") or subject
+    source: str = action.get("source", "kape-runtime")
+    payload_template = action.get("payload", {})
+
+    rendered_payload = _render(payload_template, schema_output)
+    if not isinstance(rendered_payload, dict):
+        rendered_payload = {"value": rendered_payload}
+    rendered_payload["parent_task_id"] = parent_task_id
+
+    envelope = {
+        "specversion": "1.0",
+        "id": str(uuid.uuid4()),
+        "type": event_type,
+        "source": source,
+        "time": datetime.now(tz=timezone.utc).isoformat(),
+        "datacontenttype": "application/json",
+        "data": rendered_payload,
+    }
+
+    await nats_client.publish(subject, json.dumps(envelope).encode("utf-8"))

--- a/runtime/src/kape_runtime/actions/router.py
+++ b/runtime/src/kape_runtime/actions/router.py
@@ -1,0 +1,90 @@
+# runtime/src/kape_runtime/actions/router.py
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from jsonpath_ng.ext import parse as jsonpath_parse
+
+from kape_runtime.actions.event_emitter import emit_event
+from kape_runtime.actions.save_memory import save_memory
+from kape_runtime.actions.webhook import post_webhook
+
+logger = logging.getLogger(__name__)
+
+
+def _condition_matches(condition: str | None, schema_output: dict[str, Any]) -> bool:
+    """Empty/missing condition is truthy; otherwise evaluate JSONPath against schema_output."""
+    if not condition:
+        return True
+    try:
+        expr = jsonpath_parse(condition)
+        matches = expr.find(schema_output)
+        return any(m.value for m in matches)
+    except Exception as exc:
+        logger.warning("Invalid JSONPath condition %r: %s", condition, exc)
+        return False
+
+
+async def run_actions(
+    schema_output: dict[str, Any],
+    actions: list[dict[str, Any]],
+    nats_client: Any,
+    qdrant_client: Any,
+    handler_name: str,
+    task_id: str,
+    parent_task_id: str,
+) -> list[dict[str, Any]]:
+    """Run each configured action against schema_output; collect results, never raise."""
+    results: list[dict[str, Any]] = []
+
+    for action in actions:
+        name = action.get("name", "<unnamed>")
+        action_type = action.get("type", "")
+
+        if not _condition_matches(action.get("condition"), schema_output):
+            results.append({"name": name, "type": action_type, "status": "skipped"})
+            continue
+
+        try:
+            if action_type == "event-publish":
+                await emit_event(
+                    action=action,
+                    schema_output=schema_output,
+                    parent_task_id=parent_task_id,
+                    nats_client=nats_client,
+                )
+            elif action_type == "webhook":
+                await post_webhook(action=action, schema_output=schema_output)
+            elif action_type == "save_memory":
+                await save_memory(
+                    action=action,
+                    schema_output=schema_output,
+                    qdrant_client=qdrant_client,
+                    handler_name=handler_name,
+                    task_id=task_id,
+                )
+            else:
+                results.append(
+                    {
+                        "name": name,
+                        "type": action_type,
+                        "status": "error",
+                        "error": f"unknown action type: {action_type!r}",
+                    }
+                )
+                continue
+
+            results.append({"name": name, "type": action_type, "status": "success"})
+        except Exception as exc:
+            logger.exception("Action %r (%s) failed", name, action_type)
+            results.append(
+                {
+                    "name": name,
+                    "type": action_type,
+                    "status": "error",
+                    "error": str(exc),
+                }
+            )
+
+    return results

--- a/runtime/src/kape_runtime/actions/save_memory.py
+++ b/runtime/src/kape_runtime/actions/save_memory.py
@@ -1,0 +1,37 @@
+# runtime/src/kape_runtime/actions/save_memory.py
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from jinja2 import Environment
+
+# Templates render plain memory text for Qdrant, not HTML — autoescape would
+# corrupt human-readable text. Templates come from operator-controlled CRDs.
+_jinja = Environment(autoescape=False)  # noqa: S701
+
+
+async def save_memory(
+    action: dict[str, Any],
+    schema_output: dict[str, Any],
+    qdrant_client: Any,
+    handler_name: str,
+    task_id: str,
+) -> None:
+    """Render the text template and upsert one document into a Qdrant collection."""
+    collection_name: str = action.get("collection", "kape_memory")
+    text_template: str = action.get("text_template", "")
+    rendered_text = _jinja.from_string(text_template).render(schema_output)
+
+    point = {
+        "id": str(uuid.uuid4()),
+        "payload": {
+            "text": rendered_text,
+            "handler_name": handler_name,
+            "task_id": task_id,
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        },
+    }
+
+    await qdrant_client.upsert(collection_name=collection_name, points=[point])

--- a/runtime/src/kape_runtime/actions/webhook.py
+++ b/runtime/src/kape_runtime/actions/webhook.py
@@ -1,0 +1,27 @@
+# runtime/src/kape_runtime/actions/webhook.py
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from jinja2 import Environment
+
+# Templates render JSON webhook bodies, not HTML — autoescape would corrupt
+# JSON string contents. Templates come from operator-controlled KapeHandler CRDs.
+_jinja = Environment(autoescape=False)  # noqa: S701
+_TIMEOUT_SECONDS = 10.0
+
+
+async def post_webhook(action: dict[str, Any], schema_output: dict[str, Any]) -> None:
+    """POST a Jinja2-rendered JSON body to the configured URL."""
+    url: str = action["url"]
+    body_template: str = action.get("body_template", "{}")
+    rendered = _jinja.from_string(body_template).render(schema_output)
+
+    async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+        response = await client.post(
+            url,
+            content=rendered,
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()

--- a/runtime/tests/test_actions.py
+++ b/runtime/tests/test_actions.py
@@ -1,0 +1,176 @@
+# runtime/tests/test_actions.py
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from kape_runtime.actions.event_emitter import emit_event
+from kape_runtime.actions.router import run_actions
+from kape_runtime.actions.save_memory import save_memory
+from kape_runtime.actions.webhook import post_webhook
+
+
+@pytest.mark.asyncio
+async def test_event_publish_action_publishes_cloudevent_to_nats():
+    schema_output = {
+        "decision": "change-required",
+        "reasoning": "scale up needed",
+        "nodepool": "default",
+    }
+    action = {
+        "name": "request-gitops-pr",
+        "type": "event-publish",
+        "subject": "kape.events.gitops.pr-requested",
+        "source": "kape.handlers.karpenter",
+        "event_type": "kape.events.gitops.pr-requested",
+        "payload": {
+            "nodepool": "{{ nodepool }}",
+            "reasoning": "{{ reasoning }}",
+            "prompt": "$prompt",
+        },
+    }
+    nats_client = MagicMock()
+    nats_client.publish = AsyncMock()
+
+    await emit_event(
+        action=action,
+        schema_output=schema_output,
+        parent_task_id="01PARENT",
+        nats_client=nats_client,
+    )
+
+    nats_client.publish.assert_awaited_once()
+    args, kwargs = nats_client.publish.call_args
+    subject = args[0] if args else kwargs.get("subject")
+    payload_bytes = args[1] if len(args) > 1 else kwargs.get("payload")
+    assert subject == "kape.events.gitops.pr-requested"
+
+    envelope = json.loads(payload_bytes)
+    assert envelope["specversion"] == "1.0"
+    assert envelope["type"] == "kape.events.gitops.pr-requested"
+    assert envelope["source"] == "kape.handlers.karpenter"
+    assert "id" in envelope and envelope["id"]
+    assert envelope["data"]["parent_task_id"] == "01PARENT"
+    assert envelope["data"]["nodepool"] == "default"
+    assert envelope["data"]["reasoning"] == "scale up needed"
+    # $prompt passthrough is preserved literally
+    assert envelope["data"]["prompt"] == "$prompt"
+
+
+@pytest.mark.asyncio
+async def test_webhook_action_posts_rendered_body(respx_mock):
+    schema_output = {"severity": "high", "service": "mock-api"}
+    body_template = '{"severity": "{{ severity }}", "service": "{{ service }}"}'
+    action = {
+        "name": "notify-sre",
+        "type": "webhook",
+        "url": "http://example.test/webhook",
+        "body_template": body_template,
+    }
+    route = respx_mock.post("http://example.test/webhook").mock(
+        return_value=httpx.Response(200)
+    )
+
+    await post_webhook(action=action, schema_output=schema_output)
+
+    assert route.called
+    request = route.calls.last.request
+    body = json.loads(request.content)
+    assert body == {"severity": "high", "service": "mock-api"}
+
+
+@pytest.mark.asyncio
+async def test_save_memory_action_upserts_to_qdrant():
+    schema_output = {"decision": "scale-up", "summary": "burst expected"}
+    action = {
+        "name": "remember-decision",
+        "type": "save_memory",
+        "collection": "decisions",
+        "text_template": "Decision: {{ decision }} — {{ summary }}",
+    }
+    qdrant_client = MagicMock()
+    qdrant_client.upsert = AsyncMock()
+
+    await save_memory(
+        action=action,
+        schema_output=schema_output,
+        qdrant_client=qdrant_client,
+        handler_name="karpenter-handler",
+        task_id="01TASK",
+    )
+
+    qdrant_client.upsert.assert_awaited_once()
+    _, kwargs = qdrant_client.upsert.call_args
+    assert kwargs["collection_name"] == "decisions"
+    points = kwargs["points"]
+    assert len(points) == 1
+    payload = points[0]["payload"]
+    assert payload["text"] == "Decision: scale-up — burst expected"
+    assert payload["handler_name"] == "karpenter-handler"
+    assert payload["task_id"] == "01TASK"
+    assert "timestamp" in payload and payload["timestamp"]
+
+
+@pytest.mark.asyncio
+async def test_action_failure_does_not_stop_remaining(respx_mock):
+    schema_output = {"value": 42}
+    failing_action = {
+        "name": "bad-webhook",
+        "type": "webhook",
+        "url": "http://example.test/bad",
+        "body_template": '{"value": {{ value }}}',
+    }
+    good_action = {
+        "name": "good-webhook",
+        "type": "webhook",
+        "url": "http://example.test/good",
+        "body_template": '{"value": {{ value }}}',
+    }
+    respx_mock.post("http://example.test/bad").mock(
+        return_value=httpx.Response(500, text="boom")
+    )
+    good_route = respx_mock.post("http://example.test/good").mock(
+        return_value=httpx.Response(200)
+    )
+
+    results = await run_actions(
+        schema_output=schema_output,
+        actions=[failing_action, good_action],
+        nats_client=None,
+        qdrant_client=None,
+        handler_name="h",
+        task_id="t",
+        parent_task_id="p",
+    )
+
+    assert good_route.called
+    assert len(results) == 2
+    assert results[0]["status"] == "error"
+    assert results[1]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_jsonpath_condition_false_skips_action():
+    schema_output = {"decision": "ignore"}
+    action = {
+        "name": "conditional-webhook",
+        "type": "webhook",
+        "condition": "$.decision[?(@ == 'change-required')]",
+        "url": "http://example.test/should-not-call",
+        "body_template": "{}",
+    }
+
+    # No respx mock set up — if the handler ran, httpx would raise a connect error.
+    results = await run_actions(
+        schema_output=schema_output,
+        actions=[action],
+        nats_client=None,
+        qdrant_client=None,
+        handler_name="h",
+        task_id="t",
+        parent_task_id="p",
+    )
+
+    assert len(results) == 1
+    assert results[0]["status"] == "skipped"


### PR DESCRIPTION
## Summary

Implements Phase 7.5 — the post-decision Actions Router for the kape-runtime. After the LangGraph reason node produces a `schema_output`, the router walks the configured actions list, evaluates a JSONPath condition for each, and dispatches to one of three handlers:

- **event-publish** — renders Jinja2 fields against `schema_output`, builds a CloudEvent (`specversion: 1.0`, fresh `uuid4` id, ISO-8601 `time`), injects `parent_task_id` into `data`, and publishes to a NATS subject. Preserves the `\$prompt` marker verbatim for downstream prompt passthrough.
- **webhook** — POSTs a Jinja2-rendered JSON body to a configured URL via `httpx` with a 10-second timeout, raising on non-2xx responses.
- **save_memory** — upserts a Jinja2-rendered text document into a Qdrant collection with `handler_name`, `task_id`, and ISO-8601 `timestamp` metadata.

Per-action failures are caught, logged, and recorded as `{status: "error"}` in the result list — they never abort remaining actions. JSONPath conditions that evaluate falsy mark the action as `skipped` without invoking the handler.

The `Jinja2` environments deliberately disable autoescape (with inline justification + `# noqa: S701` for the Snyk SAST check) because templates render JSON event payloads / plain memory text — autoescape would corrupt JSON strings containing `&`, `<`, `>`, `'`, or `"`. Action configs originate from operator-controlled `KapeHandler` CRDs, not untrusted user input.

## Files

- `runtime/src/kape_runtime/actions/router.py` (new)
- `runtime/src/kape_runtime/actions/event_emitter.py` (new)
- `runtime/src/kape_runtime/actions/webhook.py` (new)
- `runtime/src/kape_runtime/actions/save_memory.py` (new)
- `runtime/src/kape_runtime/actions/__init__.py` (new — re-exports)
- `runtime/tests/test_actions.py` (new — 5 tests, all green)
- `runtime/pyproject.toml` — add `jsonpath-ng>=1.6.0` and `qdrant-client>=1.12.0`

## Test plan

- [x] `conda run -n kape-runtime pytest runtime/tests/test_actions.py -v` — 5/5 pass
- [x] `conda run -n kape-runtime pytest runtime/tests/ -v` — 36/36 pass (no regressions)
- [x] `mcp__Snyk__snyk_code_scan` on `runtime/src/kape_runtime/actions/` — 3 medium findings (Jinja autoescape) accepted with inline justification; no other issues
- [ ] End-to-end verification (event-publish → second handler picks up CloudEvent with correct `parent_task_id`) deferred to integration phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)