### PR TITLE
feat(runtime): wire MCP federation + ReAct loop (Phase 7.2)

### DIFF
--- a/runtime/src/kape_runtime/graph/graph.py
+++ b/runtime/src/kape_runtime/graph/graph.py
@@ -1,15 +1,20 @@
 # runtime/src/kape_runtime/graph/graph.py
 from __future__ import annotations
 
+from typing import Sequence
+
 from jinja2 import Environment, select_autoescape
 from langchain_core.language_models import BaseChatModel
+from langchain_core.tools import BaseTool
 from langgraph.graph import END, START, StateGraph
+from langgraph.prebuilt import ToolNode
 
 from kape_runtime.config import KapeConfig, LLMConfig, SchemaConfig
 from kape_runtime.graph.nodes import (
     make_entry_router,
     make_reason_node,
     make_respond_node,
+    should_call_tools,
 )
 from kape_runtime.graph.state import AgentState
 from kape_runtime.schema_loader import make_structured_llm
@@ -20,17 +25,27 @@ def build_graph(
     kape_cfg: KapeConfig,
     llm_cfg: LLMConfig,
     schema_cfg: SchemaConfig,
+    mcp_tools: Sequence[BaseTool],
 ) -> object:
-    """Build and compile the Phase 4 minimal LangGraph: entry_router → reason → respond."""
-    # select_autoescape([]) explicitly opts out of HTML escaping for LLM prompt templates
+    """Build and compile the Phase 7.2 ReAct graph:
+
+        START -> entry_router -> reason -> [call_tools -> reason]* -> respond -> END
+
+    The reason node binds `mcp_tools` to the LLM each turn. When the LLM emits
+    tool_calls the graph routes through `call_tools` (a LangGraph ToolNode) and
+    loops back into reason. When the LLM stops emitting tool_calls, the
+    structured-output `respond` node summarises the conversation into the
+    schema-validated decision.
+    """
     jinja_env = Environment(autoescape=select_autoescape([]))
     structured_llm = make_structured_llm(llm, schema_cfg.json_schema)
 
     graph = StateGraph(AgentState)
 
     graph.add_node("entry_router_node", lambda state: {})
-    graph.add_node("reason", make_reason_node(structured_llm, kape_cfg, llm_cfg, jinja_env))
-    graph.add_node("respond", make_respond_node())
+    graph.add_node("reason", make_reason_node(llm, mcp_tools, kape_cfg, llm_cfg, jinja_env))
+    graph.add_node("call_tools", ToolNode(list(mcp_tools)))
+    graph.add_node("respond", make_respond_node(structured_llm))
 
     graph.add_edge(START, "entry_router_node")
     graph.add_conditional_edges(
@@ -38,7 +53,12 @@ def build_graph(
         make_entry_router(),
         {"reason": "reason"},
     )
-    graph.add_edge("reason", "respond")
+    graph.add_conditional_edges(
+        "reason",
+        should_call_tools,
+        {"call_tools": "call_tools", "respond": "respond"},
+    )
+    graph.add_edge("call_tools", "reason")
     graph.add_edge("respond", END)
 
     return graph.compile()

--- a/runtime/src/kape_runtime/graph/mcp.py
+++ b/runtime/src/kape_runtime/graph/mcp.py
@@ -1,0 +1,24 @@
+# runtime/src/kape_runtime/graph/mcp.py
+from __future__ import annotations
+
+from langchain_core.tools import BaseTool
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+from kape_runtime.config import ProxyConfig
+
+
+async def build_mcp_tools(proxy_cfg: ProxyConfig) -> list[BaseTool]:
+    """Connect to the kapeproxy federation endpoint and return its MCP tools.
+
+    A single MultiServerMCPClient federation handles all sidecar tools — the
+    runtime no longer maintains per-tool MCP connections.
+    """
+    client = MultiServerMCPClient(
+        {
+            "kapeproxy": {
+                "url": proxy_cfg.endpoint,
+                "transport": proxy_cfg.transport,
+            }
+        }
+    )
+    return await client.get_tools()

--- a/runtime/src/kape_runtime/graph/nodes.py
+++ b/runtime/src/kape_runtime/graph/nodes.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timezone
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 from jinja2 import Environment
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
 
 from kape_runtime.config import KapeConfig, LLMConfig
 from kape_runtime.graph.state import AgentState
@@ -25,52 +27,77 @@ def make_entry_router() -> Callable[[AgentState], str]:
 
 
 def make_reason_node(
-    structured_llm: Runnable,
+    base_llm: BaseChatModel,
+    mcp_tools: Sequence[BaseTool],
     kape_cfg: KapeConfig,
     llm_cfg: LLMConfig,
     jinja_env: Environment,
 ) -> Callable[[AgentState], dict]:
-    """Renders Jinja2 system prompt, calls structured LLM, captures output or exception."""
+    """Bind MCP tools to the LLM and run a single ReAct turn.
+
+    First turn (state.messages empty) seeds the conversation with the rendered
+    system prompt + the event wrapped in <context> tags. Subsequent turns just
+    append the LLM's AIMessage.
+    """
+    llm_with_tools = base_llm.bind_tools(list(mcp_tools))
+
     async def reason(state: AgentState) -> dict[str, Any]:
-        ctx = {
-            "handler_name": kape_cfg.handler_name,
-            "cluster_name": kape_cfg.cluster_name,
-            "namespace": kape_cfg.handler_namespace,
-            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            "event": state["event"],
-        }
-        rendered_prompt = jinja_env.from_string(llm_cfg.system_prompt).render(ctx)
-        event_json = json.dumps(state["event"], default=str)
-
-        messages = [
-            SystemMessage(content=rendered_prompt),
-            HumanMessage(content=f"<context>{event_json}</context>"),
-        ]
-
-        try:
-            result = await structured_llm.ainvoke(messages)
-            return {"schema_output": result, "parse_error": None, "messages": messages}
-        except Exception as exc:
-            logger.warning("LLM structured output failed: %s", exc)
-            return {
-                "schema_output": None,
-                "parse_error": str(exc),
-                "messages": messages,
+        if state["messages"]:
+            sent = list(state["messages"])
+            new_messages: list[Any] = []
+        else:
+            ctx = {
+                "handler_name": kape_cfg.handler_name,
+                "cluster_name": kape_cfg.cluster_name,
+                "namespace": kape_cfg.handler_namespace,
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "event": state["event"],
             }
+            rendered_prompt = jinja_env.from_string(llm_cfg.system_prompt).render(ctx)
+            event_json = json.dumps(state["event"], default=str)
+            seed = [
+                SystemMessage(content=rendered_prompt),
+                HumanMessage(content=f"<context>{event_json}</context>"),
+            ]
+            sent = seed
+            new_messages = list(seed)
+
+        ai_msg = await llm_with_tools.ainvoke(sent)
+        new_messages.append(ai_msg)
+        return {"messages": new_messages}
 
     return reason
 
 
-def make_respond_node() -> Callable[[AgentState], dict]:
-    """Sets task_status based on whether schema_output is present. No actions in Phase 4."""
-    def respond(state: AgentState) -> dict[str, Any]:
-        if state["schema_output"] is None:
+def should_call_tools(state: AgentState) -> str:
+    """Conditional edge: if the last AIMessage requested tools, run them; else respond."""
+    if not state["messages"]:
+        return "respond"
+    last = state["messages"][-1]
+    if isinstance(last, AIMessage) and getattr(last, "tool_calls", None):
+        return "call_tools"
+    return "respond"
+
+
+def make_respond_node(structured_llm: Runnable) -> Callable[[AgentState], dict]:
+    """Final pass: ask the schema-bound LLM to summarise the conversation into
+    the required JSON schema, then set task_status."""
+    async def respond(state: AgentState) -> dict[str, Any]:
+        try:
+            result = await structured_llm.ainvoke(list(state["messages"]))
             return {
+                "schema_output": result,
+                "parse_error": None,
+                "task_status": TaskStatus.Completed,
+                "should_abort": False,
+            }
+        except Exception as exc:
+            logger.warning("Structured-output respond failed: %s", exc)
+            return {
+                "schema_output": None,
+                "parse_error": str(exc),
                 "task_status": TaskStatus.SchemaValidationFailed,
                 "should_abort": True,
             }
-        return {
-            "task_status": TaskStatus.Completed,
-            "should_abort": False,
-        }
+
     return respond

--- a/runtime/src/kape_runtime/graph/state.py
+++ b/runtime/src/kape_runtime/graph/state.py
@@ -1,9 +1,10 @@
 # runtime/src/kape_runtime/graph/state.py
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from langchain_core.messages import BaseMessage
+from langgraph.graph.message import add_messages
 from typing_extensions import TypedDict
 
 from kape_runtime.models import ActionResult, TaskStatus
@@ -16,7 +17,7 @@ class AgentState(TypedDict):
     retry_task: dict | None
 
     # Reasoning
-    messages: list[BaseMessage]
+    messages: Annotated[list[BaseMessage], add_messages]
 
     # Output
     schema_output: dict[str, Any] | None

--- a/runtime/src/kape_runtime/main.py
+++ b/runtime/src/kape_runtime/main.py
@@ -11,6 +11,7 @@ import uvicorn
 from kape_runtime.config import build_llm, load_config
 from kape_runtime.consumer import ConsumerLoop
 from kape_runtime.graph.graph import build_graph
+from kape_runtime.graph.mcp import build_mcp_tools
 from kape_runtime.probe import build_probe_app
 from kape_runtime.task_service import TaskServiceClient
 from kape_runtime.tracing import setup_tracing
@@ -30,7 +31,10 @@ async def main() -> None:
     )
 
     llm = build_llm(config.llm)
-    compiled_graph = build_graph(llm, config.kape, config.llm, config.schema)
+    mcp_tools = await build_mcp_tools(config.proxy)
+    compiled_graph = build_graph(
+        llm, config.kape, config.llm, config.schema, mcp_tools=mcp_tools
+    )
 
     _ready = False
 

--- a/runtime/tests/test_graph.py
+++ b/runtime/tests/test_graph.py
@@ -1,15 +1,24 @@
 # runtime/tests/test_graph.py
 import pytest
-import json
 from unittest.mock import AsyncMock, MagicMock
-from datetime import datetime, timezone
 
-from langchain_core.messages import SystemMessage, HumanMessage
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langchain_core.tools import tool
 from jinja2 import Environment
 
 from kape_runtime.graph.state import AgentState
-from kape_runtime.graph.nodes import make_entry_router, make_reason_node, make_respond_node
-from kape_runtime.config import KapeConfig, LLMConfig
+from kape_runtime.graph.nodes import (
+    make_entry_router,
+    make_reason_node,
+    make_respond_node,
+    should_call_tools,
+)
+from kape_runtime.config import KapeConfig, LLMConfig, SchemaConfig
 from kape_runtime.models import TaskStatus
 
 
@@ -49,12 +58,12 @@ def sample_cloud_event() -> dict:
     }
 
 
-def initial_state(event: dict | None = None) -> AgentState:
+def initial_state(event: dict | None = None, messages: list | None = None) -> AgentState:
     return AgentState(
         event=event or sample_cloud_event(),
         task_id="01JXYZ",
         retry_task=None,
-        messages=[],
+        messages=messages or [],
         schema_output=None,
         parse_error=None,
         action_results=[],
@@ -64,118 +73,178 @@ def initial_state(event: dict | None = None) -> AgentState:
     )
 
 
+@tool
+def fake_mcp_tool(query: str) -> str:
+    """A fake MCP tool for testing."""
+    return f"result for {query}"
+
+
 # --- entry_router ---
 
 def test_entry_router_returns_reason_when_no_retry():
     router = make_entry_router()
     state = initial_state()
-    result = router(state)
-    assert result == "reason"
+    assert router(state) == "reason"
 
 
 def test_entry_router_returns_reason_when_retry_of_present():
     router = make_entry_router()
     event = {**sample_cloud_event(), "retry_of": "01HOLD"}
     state = initial_state(event)
-    result = router(state)
-    assert result == "reason"
+    assert router(state) == "reason"
 
 
 # --- reason node ---
 
 @pytest.mark.asyncio
-async def test_reason_node_renders_system_prompt_with_cluster_name():
+async def test_reason_node_seeds_messages_with_system_and_human_when_empty():
     kape_cfg = make_kape_config()
     llm_cfg = make_llm_config(system_prompt="Agent for {{ cluster_name }}.")
 
-    expected_output = {"decision": "ignore", "confidence": 0.9, "reasoning": "All good."}
-    mock_structured_llm = MagicMock()
-    mock_structured_llm.ainvoke = AsyncMock(return_value=expected_output)
+    bound_llm = MagicMock()
+    bound_llm.ainvoke = AsyncMock(return_value=AIMessage(content="ok"))
+    base_llm = MagicMock()
+    base_llm.bind_tools = MagicMock(return_value=bound_llm)
 
-    jinja_env = Environment()
-    reason = make_reason_node(mock_structured_llm, kape_cfg, llm_cfg, jinja_env)
-
-    state = initial_state()
-    result = await reason(state)
-
-    assert result["schema_output"] == expected_output
-    assert result["parse_error"] is None
-
-    messages = result["messages"]
-    assert any(
-        isinstance(m, SystemMessage) and "kind-local" in m.content
-        for m in messages
-    )
-
-
-@pytest.mark.asyncio
-async def test_reason_node_wraps_event_in_context_tags():
-    kape_cfg = make_kape_config()
-    llm_cfg = make_llm_config(system_prompt="Agent.")
-
-    mock_structured_llm = MagicMock()
-    mock_structured_llm.ainvoke = AsyncMock(return_value={"decision": "ignore", "confidence": 0.8, "reasoning": "OK"})
-    jinja_env = Environment()
-    reason = make_reason_node(mock_structured_llm, kape_cfg, llm_cfg, jinja_env)
+    reason = make_reason_node(base_llm, [fake_mcp_tool], kape_cfg, llm_cfg, Environment())
 
     state = initial_state()
     result = await reason(state)
 
-    messages = result["messages"]
-    human_msgs = [m for m in messages if isinstance(m, HumanMessage)]
-    assert len(human_msgs) == 1
-    assert "<context>" in human_msgs[0].content
-    assert "</context>" in human_msgs[0].content
+    sent_messages = bound_llm.ainvoke.call_args.args[0]
+    assert isinstance(sent_messages[0], SystemMessage)
+    assert "kind-local" in sent_messages[0].content
+    assert isinstance(sent_messages[1], HumanMessage)
+    assert "<context>" in sent_messages[1].content
+
+    assert "messages" in result
+    appended = result["messages"]
+    assert isinstance(appended[0], SystemMessage)
+    assert isinstance(appended[1], HumanMessage)
+    assert isinstance(appended[2], AIMessage)
 
 
 @pytest.mark.asyncio
-async def test_reason_node_captures_exception_as_parse_error():
+async def test_reason_node_appends_only_ai_message_when_history_present():
     kape_cfg = make_kape_config()
     llm_cfg = make_llm_config()
 
-    mock_structured_llm = MagicMock()
-    mock_structured_llm.ainvoke = AsyncMock(side_effect=Exception("LLM failure"))
-    jinja_env = Environment()
-    reason = make_reason_node(mock_structured_llm, kape_cfg, llm_cfg, jinja_env)
+    bound_llm = MagicMock()
+    bound_llm.ainvoke = AsyncMock(return_value=AIMessage(content="second turn"))
+    base_llm = MagicMock()
+    base_llm.bind_tools = MagicMock(return_value=bound_llm)
 
-    state = initial_state()
+    reason = make_reason_node(base_llm, [fake_mcp_tool], kape_cfg, llm_cfg, Environment())
+
+    history = [
+        SystemMessage(content="seed"),
+        HumanMessage(content="<context>{}</context>"),
+        AIMessage(content="first turn"),
+        ToolMessage(content="tool result", tool_call_id="call_1"),
+    ]
+    state = initial_state(messages=history)
     result = await reason(state)
 
-    assert result["schema_output"] is None
-    assert "LLM failure" in result["parse_error"]
+    assert result["messages"] == [AIMessage(content="second turn")]
+    sent = bound_llm.ainvoke.call_args.args[0]
+    assert sent == history
+
+
+@pytest.mark.asyncio
+async def test_reason_node_binds_mcp_tools_to_llm():
+    kape_cfg = make_kape_config()
+    llm_cfg = make_llm_config()
+
+    bound_llm = MagicMock()
+    bound_llm.ainvoke = AsyncMock(return_value=AIMessage(content="ok"))
+    base_llm = MagicMock()
+    base_llm.bind_tools = MagicMock(return_value=bound_llm)
+
+    tools = [fake_mcp_tool]
+    reason = make_reason_node(base_llm, tools, kape_cfg, llm_cfg, Environment())
+
+    await reason(initial_state())
+
+    base_llm.bind_tools.assert_called_once_with(tools)
+
+
+# --- should_call_tools router ---
+
+def test_should_call_tools_routes_to_call_tools_when_tool_calls_present():
+    state = initial_state(messages=[
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "fake_mcp_tool", "args": {"query": "x"}, "id": "c1"}],
+        ),
+    ])
+    assert should_call_tools(state) == "call_tools"
+
+
+def test_should_call_tools_routes_to_respond_when_no_tool_calls():
+    state = initial_state(messages=[AIMessage(content="final answer")])
+    assert should_call_tools(state) == "respond"
 
 
 # --- respond node ---
 
-def test_respond_node_sets_completed_when_output_present():
-    respond = make_respond_node()
-    state = initial_state()
-    state["schema_output"] = {"decision": "ignore", "confidence": 0.9, "reasoning": "OK"}
+@pytest.mark.asyncio
+async def test_respond_node_calls_structured_llm_with_messages_and_sets_completed():
+    expected_output = {"decision": "ignore", "confidence": 0.9, "reasoning": "All good."}
+    structured_llm = MagicMock()
+    structured_llm.ainvoke = AsyncMock(return_value=expected_output)
 
-    result = respond(state)
+    respond = make_respond_node(structured_llm)
+
+    history = [
+        SystemMessage(content="seed"),
+        HumanMessage(content="<context>{}</context>"),
+        AIMessage(content="final"),
+    ]
+    state = initial_state(messages=history)
+    result = await respond(state)
+
+    structured_llm.ainvoke.assert_awaited_once_with(history)
+    assert result["schema_output"] == expected_output
     assert result["task_status"] == TaskStatus.Completed
     assert result["should_abort"] is False
+    assert result["parse_error"] is None
 
 
-def test_respond_node_sets_schema_validation_failed_when_output_none():
-    respond = make_respond_node()
-    state = initial_state()
-    state["schema_output"] = None
-    state["parse_error"] = "ValidationError: field missing"
+@pytest.mark.asyncio
+async def test_respond_node_sets_schema_validation_failed_when_structured_llm_raises():
+    structured_llm = MagicMock()
+    structured_llm.ainvoke = AsyncMock(side_effect=Exception("bad schema"))
 
-    result = respond(state)
+    respond = make_respond_node(structured_llm)
+    state = initial_state(messages=[AIMessage(content="x")])
+    result = await respond(state)
+
+    assert result["schema_output"] is None
     assert result["task_status"] == TaskStatus.SchemaValidationFailed
     assert result["should_abort"] is True
+    assert "bad schema" in result["parse_error"]
 
 
 # --- graph assembly ---
 
 from kape_runtime.graph.graph import build_graph
-from kape_runtime.config import SchemaConfig
+
+
+def _build_base_llm(ai_responses: list[AIMessage]) -> MagicMock:
+    """Build a mock base_llm whose bind_tools(...) returns an LLM whose ainvoke
+    yields the given AIMessages in order across calls."""
+    bound = MagicMock()
+    it = iter(ai_responses)
+    async def _ainvoke(_msgs):
+        return next(it)
+    bound.ainvoke = AsyncMock(side_effect=_ainvoke)
+    base = MagicMock()
+    base.bind_tools = MagicMock(return_value=bound)
+    return base, bound
 
 
 @pytest.mark.asyncio
-async def test_build_graph_produces_runnable_graph():
+async def test_build_graph_routes_to_respond_when_no_tool_calls():
     kape_cfg = make_kape_config()
     llm_cfg = make_llm_config()
     schema_cfg = SchemaConfig(
@@ -183,34 +252,25 @@ async def test_build_graph_produces_runnable_graph():
         json_schema={"type": "object", "properties": {"decision": {"type": "string"}}},
     )
 
+    base_llm, _ = _build_base_llm([AIMessage(content="no tool needed")])
+
     expected_output = {"decision": "ignore", "confidence": 0.9, "reasoning": "OK"}
-    mock_ainvoke = AsyncMock(return_value=expected_output)
-    mock_base_llm = MagicMock()
-    mock_base_llm.with_structured_output.return_value = MagicMock(ainvoke=mock_ainvoke)
-
-    graph = build_graph(mock_base_llm, kape_cfg, llm_cfg, schema_cfg)
-
-    result = await graph.ainvoke(
-        AgentState(
-            event=sample_cloud_event(),
-            task_id="01JXYZ",
-            retry_task=None,
-            messages=[],
-            schema_output=None,
-            parse_error=None,
-            action_results=[],
-            task_status=None,
-            should_abort=False,
-            dry_run=False,
-        )
+    structured_ainvoke = AsyncMock(return_value=expected_output)
+    base_llm.with_structured_output = MagicMock(
+        return_value=MagicMock(ainvoke=structured_ainvoke)
     )
+
+    graph = build_graph(
+        base_llm, kape_cfg, llm_cfg, schema_cfg, mcp_tools=[fake_mcp_tool]
+    )
+    result = await graph.ainvoke(initial_state())
 
     assert result["task_status"] == TaskStatus.Completed
     assert result["schema_output"] == expected_output
 
 
 @pytest.mark.asyncio
-async def test_build_graph_schema_validation_failed_when_llm_raises():
+async def test_build_graph_invokes_tool_when_llm_emits_tool_call_then_terminates():
     kape_cfg = make_kape_config()
     llm_cfg = make_llm_config()
     schema_cfg = SchemaConfig(
@@ -218,26 +278,56 @@ async def test_build_graph_schema_validation_failed_when_llm_raises():
         json_schema={"type": "object", "properties": {"decision": {"type": "string"}}},
     )
 
-    mock_ainvoke = AsyncMock(side_effect=Exception("parse error"))
-    mock_base_llm = MagicMock()
-    mock_base_llm.with_structured_output.return_value = MagicMock(ainvoke=mock_ainvoke)
-
-    graph = build_graph(mock_base_llm, kape_cfg, llm_cfg, schema_cfg)
-
-    result = await graph.ainvoke(
-        AgentState(
-            event=sample_cloud_event(),
-            task_id="01JXYZ",
-            retry_task=None,
-            messages=[],
-            schema_output=None,
-            parse_error=None,
-            action_results=[],
-            task_status=None,
-            should_abort=False,
-            dry_run=False,
-        )
+    tool_call_msg = AIMessage(
+        content="",
+        tool_calls=[{"name": "fake_mcp_tool", "args": {"query": "hello"}, "id": "c1"}],
     )
+    final_msg = AIMessage(content="done")
+    base_llm, bound_llm = _build_base_llm([tool_call_msg, final_msg])
+
+    expected_output = {"decision": "remediate", "confidence": 0.8, "reasoning": "ran tool"}
+    structured_ainvoke = AsyncMock(return_value=expected_output)
+    base_llm.with_structured_output = MagicMock(
+        return_value=MagicMock(ainvoke=structured_ainvoke)
+    )
+
+    graph = build_graph(
+        base_llm, kape_cfg, llm_cfg, schema_cfg, mcp_tools=[fake_mcp_tool]
+    )
+    result = await graph.ainvoke(initial_state())
+
+    # bound_llm.ainvoke called twice: first turn (emits tool_call) + second turn (final)
+    assert bound_llm.ainvoke.await_count == 2
+    # respond node calls structured_llm exactly once at the end
+    structured_ainvoke.assert_awaited_once()
+    assert result["schema_output"] == expected_output
+    assert result["task_status"] == TaskStatus.Completed
+
+    # ToolMessage from fake_mcp_tool must be in conversation
+    tool_msgs = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_msgs) == 1
+    assert "result for hello" in tool_msgs[0].content
+
+
+@pytest.mark.asyncio
+async def test_build_graph_schema_validation_failed_when_structured_llm_raises():
+    kape_cfg = make_kape_config()
+    llm_cfg = make_llm_config()
+    schema_cfg = SchemaConfig(
+        name="test",
+        json_schema={"type": "object", "properties": {"decision": {"type": "string"}}},
+    )
+
+    base_llm, _ = _build_base_llm([AIMessage(content="ok")])
+    structured_ainvoke = AsyncMock(side_effect=Exception("parse error"))
+    base_llm.with_structured_output = MagicMock(
+        return_value=MagicMock(ainvoke=structured_ainvoke)
+    )
+
+    graph = build_graph(
+        base_llm, kape_cfg, llm_cfg, schema_cfg, mcp_tools=[fake_mcp_tool]
+    )
+    result = await graph.ainvoke(initial_state())
 
     assert result["task_status"] == TaskStatus.SchemaValidationFailed
     assert result["schema_output"] is None


### PR DESCRIPTION
## Summary

Phase 7.2 — Kapeproxy MCP Integration. Replaces the single-shot structured-output reason node with a real ReAct loop wired against a single MCP federation endpoint (kapeproxy):

- `runtime/graph/mcp.py` — new `build_mcp_tools(proxy_cfg)` builds a `MultiServerMCPClient` against `config.proxy.endpoint`/`transport` and returns the federated tools (async)
- `runtime/graph/nodes.py` — `reason` now binds `mcp_tools` via `base_llm.bind_tools(...)` and emits an `AIMessage` instead of a parsed dict; `respond` is the new schema-validation terminal node that runs `structured_llm` over the full conversation; `should_call_tools` is the conditional edge router
- `runtime/graph/graph.py` — `build_graph` accepts `mcp_tools` and wires `entry_router → reason → [call_tools → reason]* → respond → END` using `langgraph.prebuilt.ToolNode` for `call_tools`
- `runtime/graph/state.py` — `messages` now uses the `add_messages` reducer so each node returns only its own appended messages
- `runtime/main.py` — `await build_mcp_tools(config.proxy)` and pass into `build_graph`

> Builds on PR #19 (Phase 7.1 — `ProxyConfig`). When #19 merges this branch will rebase cleanly.

## Notes on the spec

- Spec wrote `MCPToolkit(url=...)` as pseudocode. Real symbol in `langchain-mcp-adapters` is `MultiServerMCPClient`, used directly here per team-lead clarification.
- "Namespaced tool name visible in OTEL trace" requires a live kapeproxy + collector and is deferred to e2e/integration validation. Unit tests use a mock LLM and a fake `@tool`-decorated function.

## Test plan

- [x] `conda run -n kape-runtime pytest runtime/tests/test_graph.py -v` — 12 passed
- [x] Full runtime suite — 34 passed
- [x] `MultiServerMCPClient` and `langgraph.prebuilt.ToolNode` import cleanly in the runtime env
- [x] `build_graph` ReAct test exercises `tool_call → ToolNode → reason → respond` end-to-end and asserts the `ToolMessage` lands in the conversation
- [x] `snyk_code_scan` on `runtime/src/kape_runtime/graph/` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)