### PR TITLE
feat(runtime): Phase 7.3 — load_skill tool (skills.py only, no graph wiring yet)

### DIFF
--- a/runtime/src/kape_runtime/skills.py
+++ b/runtime/src/kape_runtime/skills.py
@@ -1,0 +1,62 @@
+# runtime/src/kape_runtime/skills.py
+"""
+Lazy-loaded skill instructions.
+
+This module exposes :func:`make_load_skill_tool`, a factory that builds the
+``load_skill`` LangChain tool. The tool reads a named skill file from
+``SKILLS_DIR`` (default ``/etc/kape/skills``) and renders it through the same
+Jinja2 environment + render context used for the system prompt.
+
+INTEGRATION (Phase 7.2 — Kapeproxy MCP):
+    The ReAct graph in ``graph/graph.py`` MUST construct the tool here and
+    include it in the bound-tools list alongside the MCP tools, e.g.::
+
+        load_skill_tool = make_load_skill_tool(jinja_env, render_ctx)
+        tools = [*mcp_tools, load_skill_tool]
+        llm_with_tools = llm.bind_tools(tools)
+        tool_node = ToolNode(tools)
+
+    where ``render_ctx`` is the same dict (``handler_name``, ``cluster_name``,
+    ``namespace`` ...) used to render the system prompt. The 7.3 PR ships only
+    this module and its tests; wiring is owned by 7.2.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment
+from langchain_core.tools import tool
+
+SKILLS_DIR = Path("/etc/kape/skills")
+
+
+def _not_found(skill_name: str) -> str:
+    return (
+        f"Skill '{skill_name}' not found. "
+        "Available skills are listed in your instructions."
+    )
+
+
+def make_load_skill_tool(jinja_env: Environment, context: dict[str, Any]):
+    """Build the ``load_skill`` LangChain tool bound to a Jinja2 env and render context."""
+
+    @tool
+    def load_skill(skill_name: str) -> str:
+        """
+        Load the full instruction for a named skill.
+
+        Call this when you determine a skill is relevant to the current
+        investigation. Returns the full instruction text with all template
+        variables resolved.
+        """
+        skills_dir = SKILLS_DIR
+        if not skills_dir.exists():
+            return _not_found(skill_name)
+        path = skills_dir / f"{skill_name}.txt"
+        if not path.exists():
+            return _not_found(skill_name)
+        raw = path.read_text()
+        return jinja_env.from_string(raw).render(context)
+
+    return load_skill

--- a/runtime/tests/test_skills.py
+++ b/runtime/tests/test_skills.py
@@ -1,0 +1,65 @@
+# runtime/tests/test_skills.py
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment
+
+from kape_runtime import skills
+from kape_runtime.skills import make_load_skill_tool
+
+
+def test_load_skill_returns_rendered_content(tmp_path, monkeypatch):
+    monkeypatch.setattr(skills, "SKILLS_DIR", tmp_path)
+    (tmp_path / "check-orders.txt").write_text("Inspect orders for {{ cluster_name }}.")
+
+    load_skill = make_load_skill_tool(Environment(), {"cluster_name": "kind-local"})
+
+    result = load_skill.invoke({"skill_name": "check-orders"})
+
+    assert result == "Inspect orders for kind-local."
+
+
+def test_load_skill_missing_skill_returns_not_found(tmp_path, monkeypatch):
+    monkeypatch.setattr(skills, "SKILLS_DIR", tmp_path)
+
+    load_skill = make_load_skill_tool(Environment(), {})
+
+    result = load_skill.invoke({"skill_name": "nonexistent"})
+
+    assert "nonexistent" in result
+    assert "not found" in result.lower()
+
+
+def test_load_skill_missing_skills_dir_returns_not_found(tmp_path, monkeypatch):
+    missing_dir = tmp_path / "does" / "not" / "exist"
+    monkeypatch.setattr(skills, "SKILLS_DIR", missing_dir)
+
+    load_skill = make_load_skill_tool(Environment(), {})
+
+    result = load_skill.invoke({"skill_name": "anything"})
+
+    assert "anything" in result
+    assert "not found" in result.lower()
+
+
+def test_load_skill_renders_context_variables(tmp_path, monkeypatch):
+    monkeypatch.setattr(skills, "SKILLS_DIR", tmp_path)
+    (tmp_path / "greet.txt").write_text(
+        "Handler: {{ handler_name }} in {{ namespace }}."
+    )
+
+    load_skill = make_load_skill_tool(
+        Environment(),
+        {"handler_name": "alert-router", "namespace": "kape-system"},
+    )
+
+    result = load_skill.invoke({"skill_name": "greet"})
+
+    assert result == "Handler: alert-router in kape-system."
+
+
+def test_load_skill_is_a_langchain_tool():
+    """The factory must return a Runnable/BaseTool with a name and description."""
+    load_skill = make_load_skill_tool(Environment(), {})
+    assert load_skill.name == "load_skill"
+    assert load_skill.description and "skill" in load_skill.description.lower()


### PR DESCRIPTION
## Summary

Implements Phase 7.3 — the `load_skill` LangChain tool that lazy-loads named skill instructions from `/etc/kape/skills/<name>.txt` and renders them through the same Jinja2 environment + render context the system prompt uses.

- **Factory pattern:** `make_load_skill_tool(jinja_env, context)` returns a `@tool`-decorated callable. Both the env and the context are injected so tests (and the graph) can wire whatever they need without a hidden global.
- **Robust to missing files:** a missing `SKILLS_DIR`, or a missing `<skill>.txt` inside it, both return a not-found string — the agent never sees an exception.
- **`SKILLS_DIR` is module-level** so tests can `monkeypatch.setattr(kape_runtime.skills, "SKILLS_DIR", tmp_path)` rather than hardcoding `/etc/kape/skills`.

## Scope deviation (called out — agreed with team-lead)

The brief asked to also register `load_skill` in `runtime/src/kape_runtime/graph/graph.py` alongside `mcp_tools`. **That edit is intentionally NOT in this PR**: the new ReAct graph + `mcp_tools` list lands in Phase 7.2 (still in flight on task #4). Wiring `load_skill` into today's Phase 4-shape `graph.py` would invent a registration shape that 7.2 will then have to throw away.

The handoff is documented inline in `skills.py`'s module docstring with the exact recipe the 7.2 author should use:

```python
load_skill_tool = make_load_skill_tool(jinja_env, render_ctx)
tools = [*mcp_tools, load_skill_tool]
llm_with_tools = llm.bind_tools(tools)
tool_node = ToolNode(tools)
```

## Files

- `runtime/src/kape_runtime/skills.py` (new — 64 lines incl. docstring)
- `runtime/tests/test_skills.py` (new — 5 tests, all green)

## Test plan

- [x] `conda run -n kape-runtime pytest runtime/tests/test_skills.py -v` — 5/5 pass (rendered content, missing skill, missing dir, context vars, tool metadata)
- [x] `conda run -n kape-runtime pytest runtime/tests/ -v` — 36/36 pass (no regressions)
- [x] `mcp__Snyk__snyk_code_scan` on `runtime/src/kape_runtime/skills.py` — 0 issues
- [ ] End-to-end exercise (agent calls `load_skill("...")` and gets a rendered file) deferred to Phase 7.2 once the tool is bound to the LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)