### PR TITLE
feat(runtime): phase 7.6 tenacity retry + DLQ for graph invocations

### DIFF
--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "jsonpath-ng>=1.6.0",
     "qdrant-client>=1.12.0",
     "prometheus-client>=0.20.0",
+    "tenacity>=8.0.0",
 ]
 
 [project.scripts]

--- a/runtime/src/kape_runtime/consumer.py
+++ b/runtime/src/kape_runtime/consumer.py
@@ -7,10 +7,13 @@ import traceback
 from datetime import datetime, timezone
 from typing import Any
 
+import httpx
 import nats
+import tenacity
 from ulid import ULID
 
 from kape_runtime.config import KapeConfig, NatsConfig
+from kape_runtime.dlq import publish_dlq
 from kape_runtime.metrics import (
     kape_events_total,
     kape_llm_latency_seconds,
@@ -19,6 +22,28 @@ from kape_runtime.models import CloudEvent, TaskStatus
 from kape_runtime.task_service import TaskServiceClient
 
 logger = logging.getLogger(__name__)
+
+
+def _is_transient_llm_error(exc: BaseException) -> bool:
+    """Return True if the exception is a retryable transient LLM/API error."""
+    if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code in (429, 503):
+        return True
+    try:
+        import openai
+
+        if isinstance(exc, openai.RateLimitError):
+            return True
+    except ImportError:
+        pass
+    return False
+
+
+_llm_retry = tenacity.retry(
+    retry=tenacity.retry_if_exception(_is_transient_llm_error),
+    wait=tenacity.wait_exponential(multiplier=2, min=1, max=30),
+    stop=tenacity.stop_after_attempt(5),
+    reraise=True,
+)
 
 
 class ConsumerLoop:
@@ -33,6 +58,7 @@ class ConsumerLoop:
         self._task_svc = task_svc
         self._graph = graph
         self._kape_cfg = kape_cfg
+        self._nc: Any = None  # set in run() so process_message() can publish to DLQ
 
     async def process_message(self, msg: Any) -> None:
         """ACK → create Task → parse CloudEvent → staleness check → invoke graph → update Task."""
@@ -98,8 +124,9 @@ class ConsumerLoop:
 
         start_time = datetime.now(tz=timezone.utc)
         try:
+            retried_ainvoke = _llm_retry(self._graph.ainvoke)
             with kape_llm_latency_seconds.labels(handler=kape_cfg.handler_name).time():
-                state = await self._graph.ainvoke(
+                state = await retried_ainvoke(
                     AgentState(
                         event=raw_dict,
                         task_id=task["id"],
@@ -148,6 +175,17 @@ class ConsumerLoop:
             duration_ms = int(
                 (datetime.now(tz=timezone.utc) - start_time).total_seconds() * 1000
             )
+
+            # Route both transient (post-retry-exhaust) and non-retryable failures to DLQ
+            if self._nc is not None:
+                await publish_dlq(
+                    self._nc,
+                    kape_cfg.handler_name,
+                    task["id"],
+                    raw_bytes,
+                    exc,
+                )
+
             await self._task_svc.update_status(
                 task["id"],
                 status="Failed",
@@ -166,6 +204,7 @@ class ConsumerLoop:
     async def run(self, nats_cfg: NatsConfig) -> None:
         """Connect to NATS and run the pull consumer loop indefinitely."""
         nc = await nats.connect(nats_cfg.url)
+        self._nc = nc
         js = nc.jetstream()
         sub = await js.pull_subscribe(
             subject=nats_cfg.subject,

--- a/runtime/src/kape_runtime/consumer.py
+++ b/runtime/src/kape_runtime/consumer.py
@@ -40,7 +40,7 @@ def _is_transient_llm_error(exc: BaseException) -> bool:
 
 _llm_retry = tenacity.retry(
     retry=tenacity.retry_if_exception(_is_transient_llm_error),
-    wait=tenacity.wait_exponential(multiplier=2, min=1, max=10),
+    wait=tenacity.wait_exponential(multiplier=2, min=1, max=30),
     stop=tenacity.stop_after_attempt(5),
     reraise=True,
 )

--- a/runtime/src/kape_runtime/consumer.py
+++ b/runtime/src/kape_runtime/consumer.py
@@ -40,7 +40,7 @@ def _is_transient_llm_error(exc: BaseException) -> bool:
 
 _llm_retry = tenacity.retry(
     retry=tenacity.retry_if_exception(_is_transient_llm_error),
-    wait=tenacity.wait_exponential(multiplier=2, min=1, max=30),
+    wait=tenacity.wait_exponential(multiplier=2, min=1, max=10),
     stop=tenacity.stop_after_attempt(5),
     reraise=True,
 )

--- a/runtime/src/kape_runtime/dlq.py
+++ b/runtime/src/kape_runtime/dlq.py
@@ -1,0 +1,33 @@
+# runtime/src/kape_runtime/dlq.py
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def publish_dlq(
+    nats_client: Any,
+    handler_name: str,
+    task_id: str,
+    original_event: bytes,
+    exc: BaseException,
+) -> None:
+    """Publish a failed-event payload to the per-handler DLQ subject."""
+    subject = f"kape.events.dlq.{handler_name}"
+    body = {
+        "original_event": base64.b64encode(original_event).decode(),
+        "error": f"{type(exc).__name__}: {exc}",
+        "task_id": task_id,
+        "handler": handler_name,
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+    }
+    payload = json.dumps(body).encode()
+    try:
+        await nats_client.publish(subject, payload)
+    except Exception:
+        logger.exception("Failed to publish DLQ message for task %s", task_id)

--- a/runtime/tests/test_dlq.py
+++ b/runtime/tests/test_dlq.py
@@ -1,0 +1,38 @@
+# runtime/tests/test_dlq.py
+import base64
+import json
+
+import pytest
+from unittest.mock import AsyncMock
+
+from kape_runtime.dlq import publish_dlq
+
+
+@pytest.mark.asyncio
+async def test_publish_dlq_writes_envelope_to_per_handler_subject():
+    nc = AsyncMock()
+    raw = b'{"id":"evt-1"}'
+    exc = RuntimeError("boom")
+
+    await publish_dlq(nc, "alertmanager", "task-123", raw, exc)
+
+    nc.publish.assert_awaited_once()
+    subject, payload = nc.publish.call_args.args
+    assert subject == "kape.events.dlq.alertmanager"
+
+    body = json.loads(payload)
+    assert base64.b64decode(body["original_event"]) == raw
+    assert body["error"] == "RuntimeError: boom"
+    assert body["task_id"] == "task-123"
+    assert body["handler"] == "alertmanager"
+    assert "timestamp" in body
+
+
+@pytest.mark.asyncio
+async def test_publish_dlq_swallows_publish_failures():
+    nc = AsyncMock()
+    nc.publish.side_effect = ConnectionError("nats down")
+
+    # Should not raise — DLQ failures must not crash the consumer
+    await publish_dlq(nc, "h", "t", b"{}", RuntimeError("orig"))
+    nc.publish.assert_awaited_once()

--- a/runtime/tests/test_retry.py
+++ b/runtime/tests/test_retry.py
@@ -1,0 +1,149 @@
+# runtime/tests/test_retry.py
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import tenacity
+
+from kape_runtime.consumer import ConsumerLoop
+from kape_runtime.models import TaskStatus
+
+
+def _fresh_cloud_event() -> dict:
+    return {
+        "specversion": "1.0",
+        "type": "kape.events.alertmanager",
+        "source": "alertmanager",
+        "id": "evt-001",
+        "time": datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "datacontenttype": "application/json",
+        "data": {"alertname": "TestAlert"},
+    }
+
+
+def _make_msg(event: dict) -> MagicMock:
+    msg = MagicMock()
+    msg.data = json.dumps(event).encode()
+    msg.subject = "kape.events.alertmanager"
+    msg.ack = AsyncMock()
+    return msg
+
+
+def _make_429() -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://api.example.com/v1/messages")
+    response = httpx.Response(status_code=429, request=request)
+    return httpx.HTTPStatusError("rate limited", request=request, response=response)
+
+
+def _kape_cfg() -> MagicMock:
+    return MagicMock(
+        handler_name="test",
+        handler_namespace="default",
+        cluster_name="kind-local",
+        dry_run=False,
+        max_event_age_seconds=300,
+        schema_name="test-schema",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _patch_retry_wait(monkeypatch):
+    """Patch the module-level retry decorator to use no wait between attempts."""
+    from kape_runtime import consumer as consumer_mod
+
+    fast_retry = tenacity.retry(
+        retry=tenacity.retry_if_exception(consumer_mod._is_transient_llm_error),
+        wait=tenacity.wait_none(),
+        stop=tenacity.stop_after_attempt(5),
+        reraise=True,
+    )
+    monkeypatch.setattr(consumer_mod, "_llm_retry", fast_retry)
+
+
+@pytest.mark.asyncio
+async def test_transient_429_triggers_retry_then_succeeds():
+    msg = _make_msg(_fresh_cloud_event())
+
+    mock_task_svc = AsyncMock()
+    mock_task_svc.create.return_value = {"id": "01JXYZ"}
+
+    success_state = {
+        "task_status": TaskStatus.Completed,
+        "schema_output": {"decision": "ignore", "confidence": 0.9, "reasoning": "OK"},
+        "parse_error": None,
+        "messages": [],
+        "action_results": [],
+        "should_abort": False,
+    }
+    mock_graph = AsyncMock()
+    mock_graph.ainvoke.side_effect = [_make_429(), _make_429(), success_state]
+
+    nc = AsyncMock()
+
+    loop = ConsumerLoop(task_svc=mock_task_svc, graph=mock_graph, kape_cfg=_kape_cfg())
+    loop._nc = nc
+
+    await loop.process_message(msg)
+
+    assert mock_graph.ainvoke.await_count == 3
+    update_kwargs = mock_task_svc.update_status.call_args.kwargs
+    assert update_kwargs["status"] == "Completed"
+    nc.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_error_goes_to_dlq_immediately():
+    msg = _make_msg(_fresh_cloud_event())
+
+    mock_task_svc = AsyncMock()
+    mock_task_svc.create.return_value = {"id": "01JXYZ"}
+
+    mock_graph = AsyncMock()
+    mock_graph.ainvoke.side_effect = ValueError("schema bad")
+
+    nc = AsyncMock()
+
+    loop = ConsumerLoop(task_svc=mock_task_svc, graph=mock_graph, kape_cfg=_kape_cfg())
+    loop._nc = nc
+
+    await loop.process_message(msg)
+
+    # Non-retryable: graph called exactly once, then DLQ
+    assert mock_graph.ainvoke.await_count == 1
+    nc.publish.assert_awaited_once()
+    subject, _ = nc.publish.call_args.args
+    assert subject == "kape.events.dlq.test"
+
+    update_kwargs = mock_task_svc.update_status.call_args.kwargs
+    assert update_kwargs["status"] == "Failed"
+
+
+@pytest.mark.asyncio
+async def test_five_failed_retries_routes_to_dlq():
+    msg = _make_msg(_fresh_cloud_event())
+
+    mock_task_svc = AsyncMock()
+    mock_task_svc.create.return_value = {"id": "01JXYZ"}
+
+    mock_graph = AsyncMock()
+    mock_graph.ainvoke.side_effect = [_make_429() for _ in range(5)]
+
+    nc = AsyncMock()
+
+    loop = ConsumerLoop(task_svc=mock_task_svc, graph=mock_graph, kape_cfg=_kape_cfg())
+    loop._nc = nc
+
+    await loop.process_message(msg)
+
+    # 5 attempts then exhaust
+    assert mock_graph.ainvoke.await_count == 5
+    nc.publish.assert_awaited_once()
+    subject, payload = nc.publish.call_args.args
+    assert subject == "kape.events.dlq.test"
+    body = json.loads(payload)
+    assert "HTTPStatusError" in body["error"]
+
+    update_kwargs = mock_task_svc.update_status.call_args.kwargs
+    assert update_kwargs["status"] == "Failed"


### PR DESCRIPTION
## Summary

Implements **Phase 7.6 — Retry + DLQ** (spec: `docs/roadmap/phases/07-full-runtime/06-retry-dlq.md`).

- **`runtime/dlq.py`** — `publish_dlq(nats_client, handler, task_id, original_event, exc)` writes a JSON envelope to `kape.events.dlq.<handler>` with the base64-encoded original event, error class+message, task id, handler name, and ISO-8601 timestamp. Publish failures are logged but never re-raised so a degraded NATS connection cannot cascade-fail the consumer.
- **`runtime/consumer.py`** — module-level helpers and integration:
  - `_is_transient_llm_error(exc)` — returns True for `httpx.HTTPStatusError` with status 429/503 and `openai.RateLimitError` (lazy import; treated as never-transient if openai isn't installed).
  - `_llm_retry` — `tenacity.retry` decorator: `retry_if_exception(_is_transient_llm_error)`, `wait_exponential(multiplier=2, min=1, max=30)`, `stop_after_attempt(5)`, `reraise=True`.
  - `process_message` wraps `self._graph.ainvoke` with `_llm_retry`. On any unhandled exception (post-retry-exhaust transient OR immediate non-retryable) it publishes the DLQ envelope before marking the task `Failed`.
  - `run()` now stashes the NATS client on `self._nc` so the DLQ path is reachable from `process_message`.
- **`runtime/pyproject.toml`** — adds `tenacity>=8.0.0`.

**Placement note:** The spec's "Key Files" lists `graph/graph.py` for the retry wrapper, but the actual `ainvoke` call lives in `consumer.process_message`. Putting tenacity there keeps this change independent of Phase 7.2's in-flight graph work.

## Tests

- `runtime/tests/test_dlq.py` (new) — envelope schema and per-handler subject; `publish_dlq` swallows publish-side failures.
- `runtime/tests/test_retry.py` (new) — three behavioral tests:
  - 429 raised twice then success -> task `Completed`, no DLQ
  - `ValueError` (non-retryable) -> 1 ainvoke call, DLQ published, task `Failed`
  - 429 raised five times -> 5 ainvoke calls, DLQ published, task `Failed`

The retry-test fixture monkeypatches the module-level `_llm_retry` to use `wait_none()` so the suite stays sub-second.

Full suite: `conda run -n kape-runtime pytest runtime/tests/ -v` -> 36 passed.

## Test plan

- [x] `pytest runtime/tests/test_dlq.py runtime/tests/test_retry.py -v` (5 passed)
- [x] `pytest runtime/tests/ -v` (36 passed, ~0.26s)
- [x] `mcp__Snyk__snyk_code_scan` on `runtime/src/kape_runtime` (0 issues)
- [ ] In-cluster smoke: kill upstream LLM endpoint -> task ends `Failed`, DLQ subject `kape.events.dlq.<handler>` receives one envelope per failed event

🤖 Generated with [Claude Code](https://claude.com/claude-code)