### PR TITLE
feat(operator): phase 6 slice 2 — KapeSchema event recording

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -101,7 +101,8 @@ func main() {
 	}
 
 	// KapeSchemaReconciler
-	schemaRec := reconcilehandler.NewSchemaReconciler(schemaRepo)
+	schemaRecorder := mgr.GetEventRecorderFor("kapeschema-controller")
+	schemaRec := reconcilehandler.NewSchemaReconciler(schemaRepo, schemaRecorder)
 	if err := kapecontroller.SetupSchemaReconciler(mgr, schemaRec, cfg.MaxConcurrentReconciles); err != nil {
 		log.Error(err, "setting up KapeSchema controller")
 		os.Exit(1)

--- a/operator/cmd/playground/main.go
+++ b/operator/cmd/playground/main.go
@@ -99,7 +99,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	schemaRec := reconcilehandler.NewSchemaReconciler(schemaRepo)
+	schemaRec := reconcilehandler.NewSchemaReconciler(schemaRepo, mgr.GetEventRecorderFor("kapeschema-controller"))
 	if err := kapecontroller.SetupSchemaReconciler(mgr, schemaRec, 3); err != nil {
 		log.Error(err, "setting up KapeSchema controller")
 		os.Exit(1)

--- a/operator/controller/reconcile/schema.go
+++ b/operator/controller/reconcile/schema.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	v1alpha1 "github.com/kape-io/kape/operator/infra/api/v1alpha1"
@@ -19,12 +21,13 @@ const schemaFinalizer = "kape.io/schema-protection"
 
 // SchemaReconciler performs the full reconcile logic for KapeSchema.
 type SchemaReconciler struct {
-	schemas ports.SchemaRepository
+	schemas  ports.SchemaRepository
+	recorder record.EventRecorder
 }
 
 // NewSchemaReconciler creates a SchemaReconciler.
-func NewSchemaReconciler(schemas ports.SchemaRepository) *SchemaReconciler {
-	return &SchemaReconciler{schemas: schemas}
+func NewSchemaReconciler(schemas ports.SchemaRepository, recorder record.EventRecorder) *SchemaReconciler {
+	return &SchemaReconciler{schemas: schemas, recorder: recorder}
 }
 
 // Reconcile implements the KapeSchema reconcile loop.
@@ -76,6 +79,7 @@ func (r *SchemaReconciler) Reconcile(ctx context.Context, key types.NamespacedNa
 	if err := r.schemas.UpdateStatus(ctx, schema); err != nil {
 		return ctrl.Result{}, err
 	}
+	r.recorder.Event(schema, corev1.EventTypeNormal, "SchemaValid", "JSON Schema validated successfully")
 	return ctrl.Result{}, nil
 }
 
@@ -89,13 +93,15 @@ func (r *SchemaReconciler) handleDeletion(ctx context.Context, schema *v1alpha1.
 		for _, h := range handlers {
 			names = append(names, h.Name)
 		}
+		msg := fmt.Sprintf("Cannot delete: referenced by handlers: [%s]", strings.Join(names, ", "))
 		schema.Status.Conditions = setCondition(schema.Status.Conditions, metav1.Condition{
 			Type:    "Ready",
 			Status:  metav1.ConditionFalse,
 			Reason:  "ReferencedByHandlers",
-			Message: fmt.Sprintf("Cannot delete: referenced by handlers: [%s]", strings.Join(names, ", ")),
+			Message: msg,
 		})
 		_ = r.schemas.UpdateStatus(ctx, schema)
+		r.recorder.Event(schema, corev1.EventTypeWarning, "DeletionBlocked", msg)
 		return ctrl.Result{}, nil // blocked — no requeue; re-triggered on handler deletion
 	}
 	if err := r.schemas.RemoveFinalizer(ctx, schema, schemaFinalizer); err != nil {

--- a/operator/controller/reconcile/schema_test.go
+++ b/operator/controller/reconcile/schema_test.go
@@ -2,6 +2,7 @@ package reconcile_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1alpha1 "github.com/kape-io/kape/operator/infra/api/v1alpha1"
@@ -21,6 +23,22 @@ func newSchemaScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = v1alpha1.AddToScheme(s)
 	return s
+}
+
+func newFakeRecorder() *record.FakeRecorder {
+	return record.NewFakeRecorder(10)
+}
+
+func drainEvents(rec *record.FakeRecorder) []string {
+	var events []string
+	for {
+		select {
+		case e := <-rec.Events:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
 }
 
 func validSchema() *v1alpha1.KapeSchema {
@@ -42,7 +60,7 @@ func validSchema() *v1alpha1.KapeSchema {
 func TestSchemaReconciler_ValidSchema_SetsReadyAndHash(t *testing.T) {
 	schema := validSchema()
 	c := fake.NewClientBuilder().WithScheme(newSchemaScheme()).WithObjects(schema).WithStatusSubresource(schema).Build()
-	r := reconcile.NewSchemaReconciler(k8sadapters.NewSchemaRepository(c))
+	r := reconcile.NewSchemaReconciler(k8sadapters.NewSchemaRepository(c), newFakeRecorder())
 
 	_, err := r.Reconcile(context.Background(), types.NamespacedName{Name: "my-schema", Namespace: "kape-system"})
 
@@ -69,7 +87,7 @@ func TestSchemaReconciler_InvalidSchema_SetsNotReady(t *testing.T) {
 		},
 	}
 	c := fake.NewClientBuilder().WithScheme(newSchemaScheme()).WithObjects(schema).WithStatusSubresource(schema).Build()
-	r := reconcile.NewSchemaReconciler(k8sadapters.NewSchemaRepository(c))
+	r := reconcile.NewSchemaReconciler(k8sadapters.NewSchemaRepository(c), newFakeRecorder())
 
 	result, err := r.Reconcile(context.Background(), types.NamespacedName{Name: "bad-schema", Namespace: "kape-system"})
 
@@ -97,7 +115,7 @@ func TestSchemaReconciler_DeletionBlockedWhenHandlerReferences(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().WithScheme(newSchemaScheme()).WithObjects(schema, handler).WithStatusSubresource(schema).Build()
-	r := reconcile.NewSchemaReconciler(k8sadapters.NewSchemaRepository(c))
+	r := reconcile.NewSchemaReconciler(k8sadapters.NewSchemaRepository(c), newFakeRecorder())
 
 	_, err := r.Reconcile(context.Background(), types.NamespacedName{Name: "my-schema", Namespace: "kape-system"})
 
@@ -111,11 +129,57 @@ func TestSchemaReconciler_DeletionBlockedWhenHandlerReferences(t *testing.T) {
 func TestSchemaReconciler_FinalizerAddedOnCreate(t *testing.T) {
 	schema := validSchema()
 	c := fake.NewClientBuilder().WithScheme(newSchemaScheme()).WithObjects(schema).WithStatusSubresource(schema).Build()
-	r := reconcile.NewSchemaReconciler(k8sadapters.NewSchemaRepository(c))
+	r := reconcile.NewSchemaReconciler(k8sadapters.NewSchemaRepository(c), newFakeRecorder())
 
 	_, err := r.Reconcile(context.Background(), types.NamespacedName{Name: "my-schema", Namespace: "kape-system"})
 
 	require.NoError(t, err)
 	got, _ := k8sadapters.NewSchemaRepository(c).Get(context.Background(), types.NamespacedName{Name: "my-schema", Namespace: "kape-system"})
 	assert.Contains(t, got.Finalizers, "kape.io/schema-protection")
+}
+
+func TestSchemaReconciler_ValidSchema_EmitsSchemaValidEvent(t *testing.T) {
+	schema := validSchema()
+	c := fake.NewClientBuilder().WithScheme(newSchemaScheme()).WithObjects(schema).WithStatusSubresource(schema).Build()
+	rec := newFakeRecorder()
+	r := reconcile.NewSchemaReconciler(k8sadapters.NewSchemaRepository(c), rec)
+
+	_, err := r.Reconcile(context.Background(), types.NamespacedName{Name: "my-schema", Namespace: "kape-system"})
+
+	require.NoError(t, err)
+	events := drainEvents(rec)
+	assert.Contains(t, events, "Normal SchemaValid JSON Schema validated successfully")
+}
+
+func TestSchemaReconciler_DeletionBlockedEmitsDeletionBlockedEvent(t *testing.T) {
+	now := metav1.Now()
+	schema := validSchema()
+	schema.DeletionTimestamp = &now
+	schema.Finalizers = []string{"kape.io/schema-protection"}
+
+	handler := &v1alpha1.KapeHandler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-handler",
+			Namespace: "kape-system",
+			Labels:    map[string]string{"kape.io/schema-ref": "my-schema"},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(newSchemaScheme()).WithObjects(schema, handler).WithStatusSubresource(schema).Build()
+	rec := newFakeRecorder()
+	r := reconcile.NewSchemaReconciler(k8sadapters.NewSchemaRepository(c), rec)
+
+	_, err := r.Reconcile(context.Background(), types.NamespacedName{Name: "my-schema", Namespace: "kape-system"})
+
+	require.NoError(t, err)
+	events := drainEvents(rec)
+	// At least one event must be a Warning DeletionBlocked event
+	found := false
+	for _, e := range events {
+		if strings.HasPrefix(e, "Warning DeletionBlocked") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected a Warning DeletionBlocked event, got: %v", events)
 }


### PR DESCRIPTION
## Summary

- Adds `record.EventRecorder` to `SchemaReconciler` (`operator/controller/reconcile/schema.go`)
- Emits `SchemaValid` (Normal) event on successful JSON Schema validation
- Emits `DeletionBlocked` (Warning) event when deletion is blocked by a referencing KapeHandler
- Wires the recorder via `mgr.GetEventRecorderFor("kapeschema-controller")` in `main.go` and `cmd/playground/main.go`
- Extends `schema_test.go` with `drainEvents` helper and two new event-assertion tests (6 total)

## Acceptance Criteria

- All 6 `TestSchemaReconciler_*` tests pass (4 existing + 2 new)
- `go test ./...` — no regressions
- Snyk Code scan clean on modified files

## Test plan

- [x] `go test ./controller/reconcile/ -run TestSchemaReconciler -v` — all 6 pass
- [x] `go test ./...` — no regressions
- [x] Snyk Code scan clean on modified files
- [x] SBOM summary posted as comment (see below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)