### PR TITLE
feat(operator): slice 4 — KapeSkill cross-resource watch wiring

### DIFF
--- a/operator/controller/handler.go
+++ b/operator/controller/handler.go
@@ -42,6 +42,7 @@ func SetupHandlerReconciler(mgr manager.Manager, inner *reconcilehandler.Handler
 		Owns(&corev1.ServiceAccount{}).
 		Watches(&v1alpha1.KapeTool{}, handler.EnqueueRequestsFromMapFunc(MapToolToHandlers(mgr.GetClient()))).
 		Watches(&v1alpha1.KapeSchema{}, handler.EnqueueRequestsFromMapFunc(MapSchemaToHandlers(mgr.GetClient()))).
+		Watches(&v1alpha1.KapeSkill{}, handler.EnqueueRequestsFromMapFunc(MapSkillToHandlers(mgr.GetClient()))).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrent}).
 		Complete(r)
 }

--- a/operator/controller/watches.go
+++ b/operator/controller/watches.go
@@ -58,3 +58,28 @@ func MapSchemaToHandlers(c client.Client) func(ctx context.Context, obj client.O
 		return requests
 	}
 }
+
+// MapSkillToHandlers maps a KapeSkill change to the KapeHandlers that reference it.
+// Used as a secondary watch: KapeSkill changes re-enqueue referencing KapeHandlers.
+// Depends on Slice 3 having written kape.io/skill-ref-{name}=true labels on KapeHandler resources.
+func MapSkillToHandlers(c client.Client) func(ctx context.Context, obj client.Object) []reconcile.Request {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		skill, ok := obj.(*v1alpha1.KapeSkill)
+		if !ok {
+			return nil
+		}
+		var handlerList v1alpha1.KapeHandlerList
+		if err := c.List(ctx, &handlerList, client.MatchingLabels{
+			fmt.Sprintf("kape.io/skill-ref-%s", skill.Name): "true",
+		}); err != nil {
+			return nil
+		}
+		requests := make([]reconcile.Request, 0, len(handlerList.Items))
+		for _, h := range handlerList.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: h.Name, Namespace: h.Namespace},
+			})
+		}
+		return requests
+	}
+}

--- a/operator/controller/watches_envtest_test.go
+++ b/operator/controller/watches_envtest_test.go
@@ -1,0 +1,166 @@
+//go:build envtest
+
+package controller_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	kapecontroller "github.com/kape-io/kape/operator/controller"
+	reconcilehandler "github.com/kape-io/kape/operator/controller/reconcile"
+	domainconfig "github.com/kape-io/kape/operator/domain/config"
+	v1alpha1 "github.com/kape-io/kape/operator/infra/api/v1alpha1"
+	k8sadapters "github.com/kape-io/kape/operator/infra/k8s"
+	tomlrenderer "github.com/kape-io/kape/operator/infra/toml"
+)
+
+var enqueueScheme = func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(appsv1.AddToScheme(s))
+	utilruntime.Must(corev1.AddToScheme(s))
+	utilruntime.Must(v1alpha1.AddToScheme(s))
+	return s
+}()
+
+func TestSkillWatch_SpecChange_TriggersHandlerReconcile(t *testing.T) {
+	env := &envtest.Environment{
+		CRDDirectoryPaths: []string{"../../crds"},
+		Scheme:            enqueueScheme,
+	}
+	restCfg, err := env.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.Stop() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	mgr, err := ctrl.NewManager(restCfg, ctrl.Options{
+		Scheme:                 enqueueScheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+		LeaderElection:         false,
+	})
+	require.NoError(t, err)
+
+	k8sClient := mgr.GetClient()
+	platformCfg := domainconfig.KapeConfig{
+		ClusterName:         "envtest",
+		HandlerImage:        "kape-runtime",
+		HandlerImageVersion: "dev",
+		NatsURL:             "nats://localhost:4222",
+	}
+	cfgLoader := &envtestConfigLoader{cfg: platformCfg}
+
+	innerReconciler := reconcilehandler.NewHandlerReconciler(
+		k8sadapters.NewHandlerRepository(k8sClient),
+		k8sadapters.NewSchemaRepository(k8sClient),
+		k8sadapters.NewToolRepository(k8sClient),
+		k8sadapters.NewConfigMapAdapter(k8sClient),
+		k8sadapters.NewServiceAccountAdapter(k8sClient),
+		k8sadapters.NewDeploymentAdapter(k8sClient),
+		k8sadapters.NewScaledObjectAdapter(k8sClient),
+		tomlrenderer.NewRenderer(),
+		cfgLoader,
+	)
+	err = kapecontroller.SetupHandlerReconciler(mgr, innerReconciler, 1)
+	require.NoError(t, err)
+
+	go func() { _ = mgr.Start(ctx) }()
+
+	ns := "default"
+
+	// 1. Apply a Ready KapeSchema.
+	schema := &v1alpha1.KapeSchema{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-schema", Namespace: ns},
+		Spec: v1alpha1.KapeSchemaSpec{
+			Version: "v1",
+			JSONSchema: v1alpha1.JSONSchemaObject{
+				Type:     "object",
+				Required: []string{"msg"},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, schema))
+	schema.Status.Conditions = []metav1.Condition{{
+		Type: "Ready", Status: metav1.ConditionTrue, Reason: "Valid",
+	}}
+	require.NoError(t, k8sClient.Status().Update(ctx, schema))
+
+	// 2. Apply a KapeSkill.
+	skill := &v1alpha1.KapeSkill{
+		ObjectMeta: metav1.ObjectMeta{Name: "analyst", Namespace: ns},
+		Spec: v1alpha1.KapeSkillSpec{
+			Description: "Analyst skill",
+			Instruction: "You are an analyst.",
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, skill))
+
+	// 3. Apply a KapeHandler with the skill-ref label pre-set.
+	// Slice 3 writes this label during reconcile; here we pre-apply it to exercise the watch.
+	h := &v1alpha1.KapeHandler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-handler",
+			Namespace: ns,
+			Labels:    map[string]string{"kape.io/skill-ref-analyst": "true"},
+		},
+		Spec: v1alpha1.KapeHandlerSpec{
+			Trigger:   v1alpha1.TriggerSpec{Source: "alertmanager", Type: "kape.events.test"},
+			LLM:       v1alpha1.LLMSpec{Provider: "anthropic", Model: "claude-3", SystemPrompt: "test"},
+			SchemaRef: "test-schema",
+			Tools:     []v1alpha1.ToolRef{},
+			Actions:   []v1alpha1.ActionSpec{},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, h))
+
+	// 4. Wait for initial reconcile to create the Deployment with rollout-hash annotation.
+	depKey := types.NamespacedName{Name: "kape-handler-my-handler", Namespace: ns}
+	var initialDep appsv1.Deployment
+	require.Eventually(t, func() bool {
+		err := k8sClient.Get(ctx, depKey, &initialDep)
+		return err == nil && initialDep.Annotations["kape.io/rollout-hash"] != ""
+	}, 10*time.Second, 200*time.Millisecond, "deployment should be created with rollout-hash annotation")
+
+	initialHash := initialDep.Annotations["kape.io/rollout-hash"]
+
+	// 5. Patch the KapeSkill spec — this triggers MapSkillToHandlers via the secondary watch.
+	patch := client.MergeFrom(skill.DeepCopy())
+	skill.Spec.Instruction = "You are an expert analyst with domain expertise."
+	require.NoError(t, k8sClient.Patch(ctx, skill, patch))
+
+	// 6. Wait for the Deployment rollout-hash to change, proving the handler was re-reconciled.
+	assert.Eventually(t, func() bool {
+		var dep appsv1.Deployment
+		if err := k8sClient.Get(ctx, depKey, &dep); err != nil {
+			return false
+		}
+		newHash := dep.Annotations["kape.io/rollout-hash"]
+		return newHash != "" && newHash != initialHash
+	}, 10*time.Second, 200*time.Millisecond, "rollout-hash should change after KapeSkill spec update")
+}
+
+// envtestConfigLoader returns a fixed KapeConfig for integration tests.
+type envtestConfigLoader struct {
+	cfg domainconfig.KapeConfig
+}
+
+func (l *envtestConfigLoader) Load(_ context.Context) (domainconfig.KapeConfig, error) {
+	return l.cfg, nil
+}

--- a/operator/controller/watches_test.go
+++ b/operator/controller/watches_test.go
@@ -1,0 +1,100 @@
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kape-io/kape/operator/controller"
+	v1alpha1 "github.com/kape-io/kape/operator/infra/api/v1alpha1"
+)
+
+func newWatchScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(s)
+	return s
+}
+
+func handlerWithLabel(name, ns, labelKey, labelVal string) *v1alpha1.KapeHandler {
+	return &v1alpha1.KapeHandler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{labelKey: labelVal},
+		},
+	}
+}
+
+func TestMapSkillToHandlers_EnqueuesLabelledHandlers(t *testing.T) {
+	s := newWatchScheme()
+
+	skill := &v1alpha1.KapeSkill{
+		ObjectMeta: metav1.ObjectMeta{Name: "analyst", Namespace: "kape-system"},
+	}
+	h1 := handlerWithLabel("handler-a", "kape-system", "kape.io/skill-ref-analyst", "true")
+	h2 := &v1alpha1.KapeHandler{
+		ObjectMeta: metav1.ObjectMeta{Name: "handler-b", Namespace: "kape-system"},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(skill, h1, h2).Build()
+
+	mapper := controller.MapSkillToHandlers(c)
+	requests := mapper(context.Background(), skill)
+
+	require.Len(t, requests, 1)
+	assert.Equal(t, types.NamespacedName{Name: "handler-a", Namespace: "kape-system"}, requests[0].NamespacedName)
+}
+
+func TestMapSkillToHandlers_NoHandlers_ReturnsEmpty(t *testing.T) {
+	s := newWatchScheme()
+	skill := &v1alpha1.KapeSkill{
+		ObjectMeta: metav1.ObjectMeta{Name: "analyst", Namespace: "kape-system"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(skill).Build()
+
+	mapper := controller.MapSkillToHandlers(c)
+	requests := mapper(context.Background(), skill)
+
+	assert.Empty(t, requests)
+}
+
+func TestMapSkillToHandlers_WrongObjectType_ReturnsNil(t *testing.T) {
+	s := newWatchScheme()
+	notASkill := &v1alpha1.KapeHandler{
+		ObjectMeta: metav1.ObjectMeta{Name: "handler-a", Namespace: "kape-system"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(notASkill).Build()
+
+	mapper := controller.MapSkillToHandlers(c)
+	requests := mapper(context.Background(), notASkill)
+
+	assert.Nil(t, requests)
+}
+
+func TestMapSkillToHandlers_MultipleHandlers_EnqueuesAll(t *testing.T) {
+	s := newWatchScheme()
+	skill := &v1alpha1.KapeSkill{
+		ObjectMeta: metav1.ObjectMeta{Name: "analyst", Namespace: "kape-system"},
+	}
+	h1 := handlerWithLabel("handler-a", "kape-system", "kape.io/skill-ref-analyst", "true")
+	h2 := handlerWithLabel("handler-b", "kape-system", "kape.io/skill-ref-analyst", "true")
+	h3 := &v1alpha1.KapeHandler{
+		ObjectMeta: metav1.ObjectMeta{Name: "handler-c", Namespace: "kape-system"},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(skill, h1, h2, h3).Build()
+
+	mapper := controller.MapSkillToHandlers(c)
+	requests := mapper(context.Background(), skill)
+
+	require.Len(t, requests, 2)
+	names := []string{requests[0].NamespacedName.Name, requests[1].NamespacedName.Name}
+	assert.Contains(t, names, "handler-a")
+	assert.Contains(t, names, "handler-b")
+}


### PR DESCRIPTION
## Summary

- Adds `MapSkillToHandlers` mapper to `operator/controller/watches.go` — mirrors existing `MapToolToHandlers` and `MapSchemaToHandlers`, uses label selector `kape.io/skill-ref-{name}=true`
- Registers `KapeSkill` secondary watch in `SetupHandlerReconciler` alongside existing KapeTool and KapeSchema watches
- Adds unit tests for all mapper edge cases in `operator/controller/watches_test.go`
- Adds envtest integration test asserting KapeSkill spec change triggers rollout-hash annotation change on referencing handler Deployment (`operator/controller/watches_envtest_test.go`, build tag `envtest`)

## Acceptance Criteria

> Editing a KapeSkill's spec triggers a reconcile of every referencing KapeHandler — verified by observing the rollout-hash annotation change on the handler's Deployment within one reconcile cycle.

Demonstrated by `TestSkillWatch_SpecChange_TriggersHandlerReconcile` (envtest, build tag `envtest`).

## Dependencies

- Slice 1: `KapeSkill` CRD types and `v1alpha1.AddToScheme` registration (merged)
- Slice 3: Writes `kape.io/skill-ref-{name}=true` labels on KapeHandler (this slice reads them via the mapper)

## Notes

- No label-writing in this slice — Slice 3 owns label sync
- The envtest test pre-applies the skill-ref label to simulate Slice 3's output
- All SCA findings are pre-existing stdlib issues (Go 1.25.9 → 1.25.10 upgrade needed), not introduced by this slice
- Snyk Code scan on `operator/`: 0 issues

## Test Plan

- [ ] `go test ./operator/controller/... -run TestMapSkillToHandlers` — all 4 unit tests pass
- [ ] `go build -tags envtest ./operator/controller/...` — envtest file compiles cleanly
- [ ] `go test -tags envtest ./operator/controller/... -run TestSkillWatch` — envtest test passes (requires `KUBEBUILDER_ASSETS`)
- [ ] `go test ./operator/...` — full suite passes, no regressions