### PR TITLE
feat(phase6): KapeProxyReconciler — observability-only (slice 6)

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -94,6 +94,7 @@ func main() {
 	renderer             := tomlrenderer.NewRenderer()
 
 	statefulSetAdapt := k8sadapters.NewStatefulSetAdapter(k8sClient)
+	podReader        := k8sadapters.NewPodReaderAdapter(k8sClient)
 
 	// KapeToolReconciler
 	toolRec := reconcilehandler.NewToolReconciler(toolRepo, statefulSetAdapt, cfgLoader)
@@ -138,6 +139,13 @@ func main() {
 	// Register controller
 	if err := kapecontroller.SetupHandlerReconciler(mgr, handlerRec, cfg.MaxConcurrentReconciles); err != nil {
 		log.Error(err, "setting up KapeHandler controller")
+		os.Exit(1)
+	}
+
+	// KapeProxyReconciler
+	proxyRec := reconcilehandler.NewKapeProxyReconciler(podReader, handlerRepo)
+	if err := kapecontroller.SetupKapeProxyReconciler(mgr, proxyRec, cfg.MaxConcurrentReconciles); err != nil {
+		log.Error(err, "setting up KapeProxy controller")
 		os.Exit(1)
 	}
 

--- a/operator/controller/kapeproxy.go
+++ b/operator/controller/kapeproxy.go
@@ -1,0 +1,56 @@
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	reconcilehandler "github.com/kape-io/kape/operator/controller/reconcile"
+)
+
+// KapeProxyController is the thin controller-runtime adapter for the KapeProxyReconciler.
+type KapeProxyController struct {
+	inner *reconcilehandler.KapeProxyReconciler
+}
+
+// NewKapeProxyController creates a KapeProxyController.
+func NewKapeProxyController(inner *reconcilehandler.KapeProxyReconciler) *KapeProxyController {
+	return &KapeProxyController{inner: inner}
+}
+
+// Reconcile implements reconcile.Reconciler — delegates to the inner reconciler.
+func (r *KapeProxyController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	return r.inner.Reconcile(ctx, req.NamespacedName)
+}
+
+// SetupKapeProxyReconciler registers the KapeProxy controller with the manager.
+// It watches Pods with label kape.io/handler=* and enqueues them directly.
+func SetupKapeProxyReconciler(mgr manager.Manager, inner *reconcilehandler.KapeProxyReconciler, maxConcurrent int) error {
+	r := NewKapeProxyController(inner)
+	return ctrl.NewControllerManagedBy(mgr).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(mapHandlerPods)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrent}).
+		Complete(r)
+}
+
+// mapHandlerPods enqueues a reconcile request for each Pod that carries kape.io/handler label.
+// Pods without the label are silently ignored.
+func mapHandlerPods(_ context.Context, obj client.Object) []reconcile.Request {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return nil
+	}
+	if _, ok := labels["kape.io/handler"]; !ok {
+		return nil
+	}
+	return []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}},
+	}
+}

--- a/operator/controller/reconcile/kapeproxy.go
+++ b/operator/controller/reconcile/kapeproxy.go
@@ -1,0 +1,149 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/kape-io/kape/operator/infra/ports"
+)
+
+// ProxyHealth classifies the observed state of the kapeproxy container.
+type ProxyHealth int
+
+const (
+	ProxyHealthy   ProxyHealth = iota // container is Running and Ready
+	ProxyCrashLoop                    // container is in CrashLoopBackOff
+	ProxyNotReady                     // container exists but not ready (other reason)
+	ProxyMissing                      // no kapeproxy container found in Pod
+)
+
+const kapeproxyContainerName = "kapeproxy"
+
+// KapeProxyReconciler watches Pods labelled kape.io/handler=* and writes
+// KapeProxyReady / KapeProxyDegraded conditions on the parent KapeHandler.
+// It is observability-only: it never mutates Deployments or ConfigMaps.
+type KapeProxyReconciler struct {
+	pods     ports.PodReader
+	handlers ports.HandlerRepository
+}
+
+// NewKapeProxyReconciler creates a KapeProxyReconciler.
+func NewKapeProxyReconciler(pods ports.PodReader, handlers ports.HandlerRepository) *KapeProxyReconciler {
+	return &KapeProxyReconciler{pods: pods, handlers: handlers}
+}
+
+// Reconcile receives a Pod event, classifies kapeproxy health, and writes conditions
+// on the parent KapeHandler.
+func (r *KapeProxyReconciler) Reconcile(ctx context.Context, key types.NamespacedName) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx).WithValues("pod", key)
+
+	pod, err := r.pods.GetPod(ctx, key)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("fetching pod %s: %w", key, err)
+	}
+	if pod == nil {
+		return ctrl.Result{}, nil // Pod deleted
+	}
+
+	handlerName, ok := pod.Labels["kape.io/handler"]
+	if !ok || handlerName == "" {
+		log.V(1).Info("pod missing kape.io/handler label, skipping")
+		return ctrl.Result{}, nil
+	}
+
+	health := EvaluatePodHealth(pod)
+
+	handlerKey := types.NamespacedName{Name: handlerName, Namespace: pod.Namespace}
+	handler, err := r.handlers.Get(ctx, handlerKey)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("fetching KapeHandler %s: %w", handlerKey, err)
+	}
+	if handler == nil {
+		log.V(1).Info("KapeHandler not found, skipping", "handler", handlerKey)
+		return ctrl.Result{}, nil
+	}
+
+	handler.Status.Conditions = applyProxyConditions(handler.Status.Conditions, health)
+	if err := r.handlers.UpdateStatus(ctx, handler); err != nil {
+		return ctrl.Result{}, fmt.Errorf("updating KapeHandler status: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// EvaluatePodHealth inspects the kapeproxy container status and returns a ProxyHealth value.
+// Exported so it can be unit-tested independently of reconcile wiring.
+func EvaluatePodHealth(pod *corev1.Pod) ProxyHealth {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name != kapeproxyContainerName {
+			continue
+		}
+		if cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff" {
+			return ProxyCrashLoop
+		}
+		if cs.Ready {
+			return ProxyHealthy
+		}
+		return ProxyNotReady
+	}
+	return ProxyMissing
+}
+
+// applyProxyConditions sets KapeProxyReady and KapeProxyDegraded based on the health result.
+func applyProxyConditions(conditions []metav1.Condition, health ProxyHealth) []metav1.Condition {
+	switch health {
+	case ProxyHealthy:
+		conditions = setCondition(conditions, metav1.Condition{
+			Type:    "KapeProxyReady",
+			Status:  metav1.ConditionTrue,
+			Reason:  "Ready",
+			Message: "kapeproxy container is running and ready",
+		})
+		conditions = setCondition(conditions, metav1.Condition{
+			Type:    "KapeProxyDegraded",
+			Status:  metav1.ConditionFalse,
+			Reason:  "Healthy",
+			Message: "kapeproxy container is healthy",
+		})
+	case ProxyCrashLoop:
+		conditions = setCondition(conditions, metav1.Condition{
+			Type:    "KapeProxyReady",
+			Status:  metav1.ConditionFalse,
+			Reason:  "ContainerCrashLoop",
+			Message: "kapeproxy container is in CrashLoopBackOff",
+		})
+		conditions = setCondition(conditions, metav1.Condition{
+			Type:    "KapeProxyDegraded",
+			Status:  metav1.ConditionTrue,
+			Reason:  "RestartLoop",
+			Message: "kapeproxy container is crash-looping",
+		})
+	case ProxyNotReady:
+		conditions = setCondition(conditions, metav1.Condition{
+			Type:    "KapeProxyReady",
+			Status:  metav1.ConditionFalse,
+			Reason:  "ContainerNotReady",
+			Message: "kapeproxy container exists but is not ready",
+		})
+		conditions = setCondition(conditions, metav1.Condition{
+			Type:    "KapeProxyDegraded",
+			Status:  metav1.ConditionFalse,
+			Reason:  "Healthy",
+			Message: "kapeproxy container is not yet ready",
+		})
+	case ProxyMissing:
+		conditions = setCondition(conditions, metav1.Condition{
+			Type:    "KapeProxyReady",
+			Status:  metav1.ConditionFalse,
+			Reason:  "KapeProxyMissing",
+			Message: "no kapeproxy container found in pod",
+		})
+		// KapeProxyDegraded is intentionally not written for Missing
+	}
+	return conditions
+}

--- a/operator/controller/reconcile/kapeproxy_test.go
+++ b/operator/controller/reconcile/kapeproxy_test.go
@@ -1,0 +1,238 @@
+package reconcile_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/kape-io/kape/operator/infra/api/v1alpha1"
+	k8sadapters "github.com/kape-io/kape/operator/infra/k8s"
+	"github.com/kape-io/kape/operator/controller/reconcile"
+)
+
+// ─── scheme ──────────────────────────────────────────────────────────────────
+
+func newProxyScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+	return s
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func baseHandler(name, ns string) *v1alpha1.KapeHandler {
+	return &v1alpha1.KapeHandler{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+	}
+}
+
+func podWithKapeproxy(name, ns, handlerName string, containerStatus corev1.ContainerStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{"kape.io/handler": handlerName},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{containerStatus},
+		},
+	}
+}
+
+func podWithoutKapeproxy(name, ns, handlerName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{"kape.io/handler": handlerName},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "handler"},
+			},
+		},
+	}
+}
+
+func healthyContainerStatus() corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name:  "kapeproxy",
+		Ready: true,
+		State: corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{},
+		},
+	}
+}
+
+func crashLoopContainerStatus() corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name:         "kapeproxy",
+		Ready:        false,
+		RestartCount: 5,
+		State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{
+				Reason: "CrashLoopBackOff",
+			},
+		},
+	}
+}
+
+func notReadyContainerStatus() corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name:  "kapeproxy",
+		Ready: false,
+		State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{
+				Reason: "ContainerCreating",
+			},
+		},
+	}
+}
+
+// ─── DoD scenario 1: Healthy kapeproxy → KapeProxyReady=True ─────────────────
+
+func TestKapeProxyReconciler_HealthyPod_SetsReadyTrue(t *testing.T) {
+	s := newProxyScheme()
+	handler := baseHandler("my-handler", "kape-system")
+	pod := podWithKapeproxy("my-handler-pod-abc", "kape-system", "my-handler", healthyContainerStatus())
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(handler, pod).
+		WithStatusSubresource(handler).
+		Build()
+
+	r := reconcile.NewKapeProxyReconciler(
+		k8sadapters.NewPodReaderAdapter(c),
+		k8sadapters.NewHandlerRepository(c),
+	)
+
+	_, err := r.Reconcile(context.Background(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})
+	require.NoError(t, err)
+
+	got, _ := k8sadapters.NewHandlerRepository(c).Get(context.Background(),
+		types.NamespacedName{Name: "my-handler", Namespace: "kape-system"})
+	readyCond := findCondition(got.Status.Conditions, "KapeProxyReady")
+	require.NotNil(t, readyCond)
+	assert.Equal(t, metav1.ConditionTrue, readyCond.Status)
+	assert.Equal(t, "Ready", readyCond.Reason)
+
+	degradedCond := findCondition(got.Status.Conditions, "KapeProxyDegraded")
+	require.NotNil(t, degradedCond)
+	assert.Equal(t, metav1.ConditionFalse, degradedCond.Status)
+	assert.Equal(t, "Healthy", degradedCond.Reason)
+}
+
+// ─── DoD scenario 2: CrashLoopBackOff → KapeProxyReady=False, KapeProxyDegraded=True ──
+
+func TestKapeProxyReconciler_CrashLoop_SetsDegraded(t *testing.T) {
+	s := newProxyScheme()
+	handler := baseHandler("my-handler", "kape-system")
+	pod := podWithKapeproxy("my-handler-pod-abc", "kape-system", "my-handler", crashLoopContainerStatus())
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(handler, pod).
+		WithStatusSubresource(handler).
+		Build()
+
+	r := reconcile.NewKapeProxyReconciler(
+		k8sadapters.NewPodReaderAdapter(c),
+		k8sadapters.NewHandlerRepository(c),
+	)
+
+	_, err := r.Reconcile(context.Background(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})
+	require.NoError(t, err)
+
+	got, _ := k8sadapters.NewHandlerRepository(c).Get(context.Background(),
+		types.NamespacedName{Name: "my-handler", Namespace: "kape-system"})
+
+	readyCond := findCondition(got.Status.Conditions, "KapeProxyReady")
+	require.NotNil(t, readyCond)
+	assert.Equal(t, metav1.ConditionFalse, readyCond.Status)
+	assert.Equal(t, "ContainerCrashLoop", readyCond.Reason)
+
+	degradedCond := findCondition(got.Status.Conditions, "KapeProxyDegraded")
+	require.NotNil(t, degradedCond)
+	assert.Equal(t, metav1.ConditionTrue, degradedCond.Status)
+	assert.Equal(t, "RestartLoop", degradedCond.Reason)
+}
+
+// ─── DoD scenario 3: Pod missing kapeproxy container → KapeProxyReady=False, reason KapeProxyMissing ──
+
+func TestKapeProxyReconciler_MissingContainer_SetsMissing(t *testing.T) {
+	s := newProxyScheme()
+	handler := baseHandler("my-handler", "kape-system")
+	pod := podWithoutKapeproxy("my-handler-pod-abc", "kape-system", "my-handler")
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(handler, pod).
+		WithStatusSubresource(handler).
+		Build()
+
+	r := reconcile.NewKapeProxyReconciler(
+		k8sadapters.NewPodReaderAdapter(c),
+		k8sadapters.NewHandlerRepository(c),
+	)
+
+	_, err := r.Reconcile(context.Background(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})
+	require.NoError(t, err)
+
+	got, _ := k8sadapters.NewHandlerRepository(c).Get(context.Background(),
+		types.NamespacedName{Name: "my-handler", Namespace: "kape-system"})
+
+	readyCond := findCondition(got.Status.Conditions, "KapeProxyReady")
+	require.NotNil(t, readyCond)
+	assert.Equal(t, metav1.ConditionFalse, readyCond.Status)
+	assert.Equal(t, "KapeProxyMissing", readyCond.Reason)
+}
+
+// ─── Unit test: evaluatePodHealth pure function ───────────────────────────────
+
+func TestEvaluatePodHealth_Healthy(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{healthyContainerStatus()},
+		},
+	}
+	result := reconcile.EvaluatePodHealth(pod)
+	assert.Equal(t, reconcile.ProxyHealthy, result)
+}
+
+func TestEvaluatePodHealth_CrashLoop(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{crashLoopContainerStatus()},
+		},
+	}
+	result := reconcile.EvaluatePodHealth(pod)
+	assert.Equal(t, reconcile.ProxyCrashLoop, result)
+}
+
+func TestEvaluatePodHealth_NotReady(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{notReadyContainerStatus()},
+		},
+	}
+	result := reconcile.EvaluatePodHealth(pod)
+	assert.Equal(t, reconcile.ProxyNotReady, result)
+}
+
+func TestEvaluatePodHealth_Missing(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "handler", Ready: true},
+			},
+		},
+	}
+	result := reconcile.EvaluatePodHealth(pod)
+	assert.Equal(t, reconcile.ProxyMissing, result)
+}

--- a/operator/infra/k8s/pod_reader.go
+++ b/operator/infra/k8s/pod_reader.go
@@ -1,0 +1,41 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PodReaderAdapter implements ports.PodReader using a controller-runtime client.
+type PodReaderAdapter struct {
+	client client.Client
+}
+
+// NewPodReaderAdapter creates a PodReaderAdapter.
+func NewPodReaderAdapter(c client.Client) *PodReaderAdapter {
+	return &PodReaderAdapter{client: c}
+}
+
+// GetPod fetches a single Pod by namespaced name. Returns nil, nil when not found.
+func (a *PodReaderAdapter) GetPod(ctx context.Context, key types.NamespacedName) (*corev1.Pod, error) {
+	var pod corev1.Pod
+	if err := a.client.Get(ctx, key, &pod); err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+	return &pod, nil
+}
+
+// ListByHandlerName returns all Pods in namespace with label kape.io/handler=<name>.
+func (a *PodReaderAdapter) ListByHandlerName(ctx context.Context, namespace, handlerName string) ([]corev1.Pod, error) {
+	var list corev1.PodList
+	if err := a.client.List(ctx, &list,
+		client.InNamespace(namespace),
+		client.MatchingLabels{"kape.io/handler": handlerName},
+	); err != nil {
+		return nil, fmt.Errorf("listing pods for handler %s/%s: %w", namespace, handlerName, err)
+	}
+	return list.Items, nil
+}

--- a/operator/infra/ports/pod.go
+++ b/operator/infra/ports/pod.go
@@ -1,0 +1,18 @@
+package ports
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// PodReader provides read-only access to Pod resources.
+// Implementations must never mutate Pods.
+type PodReader interface {
+	// GetPod fetches a single Pod by namespaced name. Returns nil, nil when not found.
+	GetPod(ctx context.Context, key types.NamespacedName) (*corev1.Pod, error)
+
+	// ListByHandlerName returns all Pods in the given namespace with label kape.io/handler=<name>.
+	ListByHandlerName(ctx context.Context, namespace, handlerName string) ([]corev1.Pod, error)
+}


### PR DESCRIPTION
## Summary

- Adds `KapeProxyReconciler` that watches Pods with label `kape.io/handler=*`, classifies the kapeproxy container health, and writes `KapeProxyReady` / `KapeProxyDegraded` conditions on the parent `KapeHandler`
- Introduces `PodReader` port interface (`GetPod`, `ListByHandlerName`) and `PodReaderAdapter` (k8s adapter) for read-only Pod access
- Adds pure `EvaluatePodHealth` function covering four states: `ProxyHealthy`, `ProxyCrashLoop`, `ProxyNotReady`, `ProxyMissing` — with full unit and fake-client tests for all three DoD scenarios

## Test Plan

- [ ] All 7 new tests pass: `TestKapeProxyReconciler_HealthyPod_SetsReadyTrue`, `TestKapeProxyReconciler_CrashLoop_SetsDegraded`, `TestKapeProxyReconciler_MissingContainer_SetsMissing`, `TestEvaluatePodHealth_Healthy`, `TestEvaluatePodHealth_CrashLoop`, `TestEvaluatePodHealth_NotReady`, `TestEvaluatePodHealth_Missing`
- [ ] `go test ./...` passes with no failures across all operator packages
- [ ] Snyk Code scan: 0 issues found in `operator/`
- [ ] KapeProxyReconciler is observability-only — it only calls `handlers.UpdateStatus`, never touches Deployments or ConfigMaps

🤖 Generated with [Claude Code](https://claude.ai/claude-code)