### PR TITLE
chore: add .claude/standup.json for /standup skill

### DIFF
--- a/.claude/standup.json
+++ b/.claude/standup.json
@@ -1,0 +1,17 @@
+{
+  "datasources": [
+    {
+      "name": "bug",
+      "description": "Failed GitHub Actions runs in the last 7 days — signals potential regressions needing a bug issue",
+      "command": "gh run list --status failure --limit 20 --json databaseId,displayTitle,workflowName,conclusion,updatedAt,headBranch"
+    },
+    {
+      "name": "enhancement",
+      "description": "Snyk code scan findings in the operator module — security issues that may warrant an enhancement or bug issue",
+      "tool": "mcp__Snyk__snyk_code_scan",
+      "params": {
+        "scanPath": "./operator"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/standup.json` with two datasources tailored to this repo
- `bug`: polls failed GitHub Actions runs — CI failures that aren't tracked by a bug issue surface as **ACT NOW**
- `enhancement`: runs Snyk code scan on `./operator` — security findings that lack a tracking issue surface as **ACT NOW**

## Why these datasources

No external bug tracker (Jira/Sentry) is in use, so the signals come from GitHub CI and Snyk — the two external checks that already run on this codebase.

## Test plan

- [ ] Run `/standup` and confirm the report renders the 5 buckets
- [ ] Verify CI failures appear in ACT NOW when no matching `bug`-labeled issue exists
- [ ] Verify Snyk findings appear in ACT NOW when not yet tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)