### PR TITLE
chore(standup): rename Snyk datasource label to snyk-finding

### DIFF
--- a/.claude/standup.json
+++ b/.claude/standup.json
@@ -6,8 +6,8 @@
       "command": "gh run list --status failure --limit 20 --json databaseId,displayTitle,workflowName,conclusion,updatedAt,headBranch"
     },
     {
-      "name": "enhancement",
-      "description": "Snyk code scan findings in the operator module — security issues that may warrant an enhancement or bug issue",
+      "name": "snyk-finding",
+      "description": "Snyk code scan findings in the operator module — security issues tracked via the snyk-finding label, separate from GitHub's default enhancement label",
       "tool": "mcp__Snyk__snyk_code_scan",
       "params": {
         "scanPath": "./operator"


### PR DESCRIPTION
## Summary

- Rename the `enhancement` datasource in `.claude/standup.json` to `snyk-finding`
- The previous name collided with GitHub's default `enhancement` label, causing four roadmap follow-up issues (#12, #13, #37, #38) to be reconciled against Snyk findings every standup run
- On clean Snyk scans (the normal case), all four were bucketed as "Stale", which mischaracterized them as candidates for closure
- The new `snyk-finding` label is owned by the Snyk integration and applied only to genuine Snyk-surfaced issues; `enhancement` retains its GitHub-default meaning

## Side effects

- New repo label `snyk-finding` (description: "Snyk-surfaced security finding requiring a fix", color `#d73a4a`) was created out-of-band
- A classification sweep confirmed none of the four currently-open `enhancement` issues are Snyk findings; no label changes were applied

## Test plan

- [ ] Next `/standup` run uses `snyk-finding` as the datasource label
- [ ] Roadmap follow-up issues (#12, #13, #37, #38) no longer appear in the Stale bucket of the standup report

🤖 Generated with [Claude Code](https://claude.com/claude-code)