### PR TITLE
fix(task-service): add --migrate-only flag

### DIFF
--- a/task-service/cmd/task-service/main.go
+++ b/task-service/cmd/task-service/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"net/http"
 	"os"
@@ -18,6 +19,9 @@ import (
 )
 
 func main() {
+	migrateOnly := flag.Bool("migrate-only", false, "run database migrations and exit")
+	flag.Parse()
+
 	// Config from environment
 	pgDSN := envOrDefault("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/kape?sslmode=disable")
 	addr := envOrDefault("ADDR", ":8080")
@@ -25,6 +29,12 @@ func main() {
 	// Run migrations
 	if err := postgres.RunMigrations(pgDSN); err != nil {
 		log.Fatalf("migrations: %v", err)
+	}
+
+	// When --migrate-only is set, exit after migrations complete successfully.
+	if *migrateOnly {
+		log.Println("migrations complete")
+		return
 	}
 
 	// Connect DB


### PR DESCRIPTION
## What was broken

`task-service/Makefile` line 32 runs:
```makefile
migrate:
	go run ./cmd/task-service --migrate-only
```

But `main.go` did not parse any CLI flags. The `--migrate-only` argument was silently ignored by Go's `flag` package (since `flag.Parse()` was never called), so `make migrate` started a full HTTP server instead of running migrations and exiting. As a workaround, `.claude/settings.json` had a deny rule blocking `make migrate`.

## How it's fixed

Added `flag.Parse()` and a `--migrate-only` boolean flag at the top of `main()`. When the flag is set:

1. Migrations run via the existing `postgres.RunMigrations(pgDSN)` call (unchanged).
2. The process logs `"migrations complete"` and returns — exit code 0.
3. If migrations fail, `log.Fatalf` exits non-zero (existing behaviour).

The HTTP server, DB connection, partition setup, and all other application wiring are only reached when `--migrate-only` is **not** set, preserving normal server startup.

Only `task-service/cmd/task-service/main.go` was touched — no other modules changed.

## SBOM Summary

| Module | Components | Flagged |
|---|---|---|
| adapters | N/A | N/A |
| operator | N/A | N/A |
| task-service | 0 issues (SCA clean) | none |

Generated via Snyk SCA scan (MCP) — 2026-05-16T00:00:00Z

> Note: `snyk_sbom_scan` MCP tool requires a pre-generated SBOM file as input; no SBOM generation MCP tool is available. SCA scan (`snyk_sca_scan`) confirmed 0 open-source vulnerabilities in task-service. Snyk SAST scan (`snyk_code_scan`) on the changed file also returned 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)