### PR TITLE
chore(skills): scaffold Matt Pocock skill configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Issues live in GitHub Issues on `dzungtr/kape` and are managed via the `gh` CLI.
 
 ### Triage labels
 
-Canonical role names are used as-is (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+Maps Pocock canonical roles onto this repo's taxonomy (`needs-info` → `needs/info`, `ready-for-{agent,human}` → single `ready`; audience encoded via assignee). See `docs/agents/triage-labels.md` and `docs/agent-rituals.md`.
 
 ### Domain docs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,17 @@ Before creating any PR, run SBOM generation for all Go modules and post a summar
 
    If `snyk_sbom_scan` returns no component count, write "N/A".
    If any module scan fails, write "FAILED: <error message>" in the Components column and "N/A" in the Flagged column for that module row.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues on `dzungtr/kape` and are managed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical role names are used as-is (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This repo uses the **single-context** layout:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on `dzungtr/kape`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,15 +1,42 @@
 # Triage Labels
 
-The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+The Matt Pocock skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo, which follows the taxonomy defined in [`docs/superpowers/specs/2026-05-16-github-label-system-design.md`](../superpowers/specs/2026-05-16-github-label-system-design.md) and the consumption contracts in [`docs/agent-rituals.md`](../agent-rituals.md).
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
-| -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
-| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+## Mapping
 
-When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+| Pocock canonical role | Our label    | Meaning                                                |
+| --------------------- | ------------ | ------------------------------------------------------ |
+| `needs-triage`        | `needs-triage` | Maintainer needs to evaluate this issue              |
+| `needs-info`          | `needs/info`   | Waiting on reporter for more information             |
+| `ready-for-agent`     | `ready`        | Triage complete, AFK-agent picks up (no assignee)    |
+| `ready-for-human`     | `ready`        | Triage complete, human picks up (human assignee)     |
+| `wontfix`             | `wontfix`     | Will not be actioned                                  |
 
-Edit the right-hand column to match whatever vocabulary you actually use.
+When a Pocock skill mentions a canonical role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from the right-hand column.
+
+## Important divergences from Pocock defaults
+
+**Audience is encoded via assignee, not label.** Our taxonomy does not split "ready" into `ready-for-agent` vs `ready-for-human`. Both map to the single `ready` label. To distinguish:
+
+- `ready` + no assignee → an AFK agent can pick it up
+- `ready` + human assignee → reserved for a human
+- `ready` + agent identifier in assignee → an agent is already working it
+
+If a Pocock skill expects a label-level distinction, infer it from the assignee instead.
+
+**`ready` is a derived label, not directly set.** Per the spec, `ready` is auto-applied by the Triage ritual when an issue has exactly one category, one area, one commitment, optionally one phase, **and** no open `needs/*` labels. It is auto-cleared when those preconditions break.
+
+A Pocock skill that wants to "mark an issue ready" should instead:
+
+1. Ensure the issue has one category (`bug`, `enhancement`, `feature`, etc.)
+2. Ensure it has one `area/*` label
+3. Ensure it has one commitment label (`committed`, `stretch`, `backlog`)
+4. Resolve and remove any open `needs/*` labels
+
+The Triage ritual will then set `ready` automatically.
+
+**Additional `needs/*` sub-labels.** Beyond `needs/info`, our taxonomy includes `needs/repro` (bug needs reproduction steps) and `needs/decision` (awaiting maintainer call). If a Pocock skill detects either condition, apply the more specific sub-label.
+
+## When the mapping is ambiguous
+
+If a Pocock skill action doesn't cleanly fit one of the rows above, prefer the project's taxonomy (`docs/agent-rituals.md`) over Pocock defaults. The skill should adapt to the project, not the other way around.


### PR DESCRIPTION
## Summary

- Scaffolds the per-repo configuration that Matt Pocock's engineering skills (`to-issues`, `to-prd`, `triage`, `grill-with-docs`, etc.) expect.
- Adds an `## Agent skills` block to `CLAUDE.md` pointing at three new docs under `docs/agents/`:
  - **Issue tracker** — GitHub via `gh` CLI on `dzungtr/kape`
  - **Triage labels** — canonical role names used as-is (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`)
  - **Domain docs** — single-context layout (`CONTEXT.md` + `docs/adr/` at the repo root)
- Re-run `/setup-matt-pocock-skills` only if switching trackers or restarting from scratch; otherwise edit `docs/agents/*.md` directly.

## Test plan

- [ ] Verify the three docs render correctly on the GitHub UI.
- [ ] Confirm `CLAUDE.md` still parses (no other sections disturbed).
- [ ] Run `/triage` against an existing issue and confirm it applies labels from `docs/agents/triage-labels.md` rather than inventing new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)