### PR TITLE
feat: roll out 40-label GitHub taxonomy + automation

### DIFF
--- a/.claude/skills/apply-labels/SKILL.md
+++ b/.claude/skills/apply-labels/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: apply-labels
+description: Apply the kape-io label taxonomy (defined in docs/superpowers/specs/2026-05-16-github-label-system-design.md, consumed per docs/agent-rituals.md) to a GitHub issue or PR. Use when the user asks to label an issue/PR, when a new issue or PR lacks the required dimensions (area/*, category, commitment for issues), or as part of a triage pass. Reads context, derives labels deterministically where possible, and asks the user before applying ambiguous labels. Never sets commitment, urgent, or blocked without an observable trigger and human confirmation.
+---
+
+# Apply labels skill
+
+Apply the kape-io label taxonomy to a GitHub issue or PR. The full rule
+set lives in `docs/agent-rituals.md`; this skill is the operational
+recipe for executing it on one target at a time.
+
+## Inputs
+
+One of:
+- A PR number (e.g., "label PR 96") — fetch via `gh pr view <n>`
+- An issue number (e.g., "label issue 84") — fetch via `gh issue view <n>`
+- No argument — default to the current branch's PR via `gh pr view --json number,title,body,labels,files`
+
+If the user gives a bare number, infer PR vs issue by trying `gh pr view <n>` first; fall back to `gh issue view <n>` if it 404s.
+
+## What to fetch
+
+For a PR:
+```
+gh pr view <n> --json number,title,body,labels,files,headRefName
+```
+
+For an issue:
+```
+gh issue view <n> --json number,title,body,labels,milestone,assignees
+```
+
+## Derivation rules
+
+### Always-safe (apply without asking)
+
+These have observable triggers. Apply directly and report.
+
+**`area/*` from PR changed files** — apply when one area accounts for ≥80% of changed paths.
+
+| If changed files match           | Set                |
+|----------------------------------|--------------------|
+| `operator/**`                    | `area/operator`    |
+| `task-service/**`                | `area/task-service`|
+| `adapters/**`                    | `area/adapters`    |
+| `kapeproxy/**`                   | `area/kapeproxy`   |
+| `runtime/**`                     | `area/runtime`     |
+| `dashboard/**`                   | `area/dashboard`   |
+| `helm/**`                        | `area/helm`        |
+| `crds/**`                        | `area/crds`        |
+| `docs/**` (excluding `docs/superpowers/specs/**`), `README.md`, `CONTRIBUTING.md` | `area/docs` |
+| `.github/**`, `tools/**`         | `area/ci`          |
+
+**`area/*` from issue title** — apply when exactly one keyword bucket matches the title (case-insensitive).
+
+| Title contains                                          | Set                |
+|---------------------------------------------------------|--------------------|
+| operator, reconciler, KapeHandler, KapeTool, KapeSchema, CRD validation | `area/operator` |
+| task-service, task service, OpenAPI                     | `area/task-service`|
+| adapter, AlertManager, audit adapter                    | `area/adapters`    |
+| kapeproxy, MCP proxy                                    | `area/kapeproxy`   |
+| runtime, LangGraph, Python, handler routes              | `area/runtime`     |
+| dashboard, SSE, EventSource, OAuth2 Proxy               | `area/dashboard`   |
+| helm, chart, template                                   | `area/helm`        |
+| CRD, CEL, XValidation                                   | `area/crds`        |
+| docs, README, runbook, CHANGELOG                        | `area/docs`        |
+| CI, workflow, Actions, Snyk                             | `area/ci`          |
+| NATS, Postgres, CloudNativePG, cert-manager, ESO, External Secrets | `area/infra` |
+
+**Category from PR paths** — apply when all changed files match one category bucket.
+
+| If all changed files are        | Set      |
+|---------------------------------|----------|
+| `docs/superpowers/specs/**`     | `spec`   |
+| under a `docs/` tree, no source | `docs`   |
+| test files (`*_test.go`, `test_*.py`, `*.test.ts`, `tests/**`) | `test` |
+
+**`phase/Mx-*` from issue title** — apply when title matches `[Pn/...]`.
+
+| Prefix       | Set                  |
+|--------------|----------------------|
+| `[P6/...]`   | `phase/M2-operator`  |
+| `[P7/...]`   | `phase/M3-runtime`   |
+| `[P8/...]`   | `phase/M4-security`  |
+| `[P9/...]`   | `phase/M5-dashboard` |
+| `[P10/...]`  | `phase/M6-release`   |
+
+### Ask-before-applying
+
+These require judgment. Propose and confirm.
+
+- **Ambiguous area** — when multiple area buckets match a PR's files (e.g., a PR touching both `operator/` and `crds/`). List the matches, recommend the dominant one, ask.
+- **Category** — for issues (which have no file paths) and PRs that span code. Look at title/body, propose one of `bug`, `enhancement`, `feature`, `refactor`, `redesign`, `security`, `chore`. Confirm.
+- **`needs-triage` / `ready`** — for issues. If category + area + commitment all present and no open `needs/*`, propose `ready`. Otherwise propose `needs-triage`.
+
+### Never apply autonomously
+
+The spec defines these labels as agent-only-with-cause. Always require the user to set them explicitly.
+
+- **`committed` / `stretch` / `backlog`** — commitment is a planning decision. Suggest based on milestone presence (issue in milestone → suggest `committed`; no milestone → suggest `backlog`), but require user confirmation.
+- **`urgent`** — requires "Reason:" line in body and a triggering condition (Snyk severity ≥ high, broken main CI, linked incident). Never apply unless the user explicitly asks.
+- **`blocked`** — requires "Blocked by: <ref>" line. Never apply without confirmation.
+- **`good first issue` / `help wanted`** — maintainer signal, never auto-applied.
+
+## Process
+
+1. **Resolve the target.** Determine PR vs issue from input.
+2. **Fetch context.** Read JSON above; print title and current labels in one short line.
+3. **Derive.** Walk the always-safe rules; collect proposed adds. Walk the ask-before-applying rules; collect proposed adds that need confirmation.
+4. **Diff.** Compute `to_add = derived - existing`. Skip any label already present.
+5. **Confirm ambiguous adds.** Present a single message: "I'll add [auto-derived list]. For [ambiguous categories], I propose [X] — confirm or override?" Wait for the user.
+6. **Apply.** `gh issue edit <n> --add-label "<csv>"` or `gh pr edit <n> --add-label "<csv>"`.
+7. **Report.** One line summary: `Labeled #<n>: added [<list>]. Existing: [<unchanged list>].`
+
+## Edge cases
+
+- **No `area/*` derivable** — for PRs, list the changed paths and ask the user which area. For issues, fall through to `needs-triage`.
+- **PR already has labels** — only add missing ones. Never remove labels unless the user asks.
+- **Target is closed or merged** — refuse with a one-line message. Labeling closed work has no consumer.
+- **`gh` not authenticated** — print the auth command and stop.
+
+## Reference
+
+Full rules and the rationale for each label live in:
+- `docs/superpowers/specs/2026-05-16-github-label-system-design.md` (spec)
+- `docs/agent-rituals.md` (rituals — read before adding new label-application logic)
+
+Update both files if rules change, then update this skill in lockstep.

--- a/.claude/standup.json
+++ b/.claude/standup.json
@@ -7,11 +7,21 @@
     },
     {
       "name": "snyk-finding",
-      "description": "Snyk code scan findings in the operator module — security issues tracked via the snyk-finding label, separate from GitHub's default enhancement label",
+      "description": "Snyk code scan findings in the operator module — security issues tracked via the snyk-finding label",
       "tool": "mcp__Snyk__snyk_code_scan",
       "params": {
         "scanPath": "./operator"
       }
+    },
+    {
+      "name": "urgent-issues",
+      "description": "Open issues labelled urgent — surfaced top of standup per agent-rituals.md",
+      "command": "gh issue list --state open --label urgent --json number,title,labels,assignees,milestone,updatedAt,body"
+    },
+    {
+      "name": "blocked-issues",
+      "description": "Open issues labelled blocked — surfaced in Stuck bucket when blocked > 3 days per agent-rituals.md",
+      "command": "gh issue list --state open --label blocked --json number,title,labels,assignees,milestone,updatedAt,body"
     }
   ]
 }

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -133,8 +133,3 @@
 - name: snyk-finding
   color: "d73a4a"
   description: "Snyk-surfaced security finding requiring a fix"
-
-# --- Transitional (retired in T12) ---
-- name: roadmap-sync
-  color: "0075ca"
-  description: "Roadmap sync issue (transitional — retired after backfill)"

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,140 @@
+# .github/labels.yaml
+# Authoritative source for repo labels. Synced by tools/sync-labels.sh.
+# Schema: name (string), color (6-hex no #), description (<=100 chars).
+# See docs/superpowers/specs/2026-05-16-github-label-system-design.md for design.
+
+# --- Category (flat, exactly one per issue) ---
+- name: bug
+  color: d73a4a
+  description: "Defect — something is broken"
+- name: enhancement
+  color: a2eeef
+  description: "Improve an existing capability"
+- name: feature
+  color: 84b6eb
+  description: "New capability that doesn't exist yet"
+- name: refactor
+  color: fbca04
+  description: "Internal restructure, no behaviour change"
+- name: redesign
+  color: ff9f1c
+  description: "Reshape architecture/UX/API — behaviour changes"
+- name: security
+  color: b60205
+  description: "Security-relevant change (vuln fix, hardening, policy)"
+- name: docs
+  color: 0075ca
+  description: "Documentation-only"
+- name: chore
+  color: ededed
+  description: "Deps, config, build, tooling"
+- name: test
+  color: c5def5
+  description: "Test-only changes"
+- name: spec
+  color: 5319e7
+  description: "Design or spec doc under docs/superpowers/specs/"
+
+# --- Area (area/*, one per issue) ---
+- name: area/operator
+  color: 0e8a16
+  description: "Go operator (CRDs, reconcilers)"
+- name: area/task-service
+  color: 0e8a16
+  description: "Go task-service"
+- name: area/adapters
+  color: 0e8a16
+  description: "Go event adapters (alertmanager, k8s-audit)"
+- name: area/kapeproxy
+  color: 0e8a16
+  description: "Go MCP proxy"
+- name: area/runtime
+  color: 0e8a16
+  description: "Python LangGraph runtime"
+- name: area/dashboard
+  color: 0e8a16
+  description: "TypeScript dashboard"
+- name: area/helm
+  color: 0e8a16
+  description: "Helm charts and manifests"
+- name: area/crds
+  color: 0e8a16
+  description: "CRD schemas and CEL validation"
+- name: area/docs
+  color: 0e8a16
+  description: "docs/, README, runbooks (excludes spec docs)"
+- name: area/ci
+  color: 0e8a16
+  description: ".github/workflows, tooling"
+- name: area/infra
+  color: 0e8a16
+  description: "NATS, Postgres, cert-manager, External Secrets Operator"
+
+# --- Phase (phase/Mx-*, one per roadmap-tracked issue) ---
+- name: phase/M2-operator
+  color: 5319e7
+  description: "Phase 6 — Full Operator"
+- name: phase/M3-runtime
+  color: 5319e7
+  description: "Phase 7 — Full Runtime"
+- name: phase/M4-security
+  color: 5319e7
+  description: "Phase 8 — K8s Audit + Security"
+- name: phase/M5-dashboard
+  color: 5319e7
+  description: "Phase 9 — Dashboard"
+- name: phase/M6-release
+  color: 5319e7
+  description: "Phase 10 — Helm + Examples + Polish"
+
+# --- Commitment (flat, mutually exclusive) ---
+- name: committed
+  color: 0e8a16
+  description: "Belongs to its milestone. Counts against milestone capacity."
+- name: stretch
+  color: fbca04
+  description: "Targeted for milestone if capacity allows. First to slip."
+- name: backlog
+  color: c5def5
+  description: "Not committed to any milestone. Re-evaluated each cycle."
+
+# --- Signals (flat, additive) ---
+- name: urgent
+  color: b60205
+  description: "Interrupt rule. Standup ranks above committed. Body MUST have Reason:"
+- name: blocked
+  color: e99695
+  description: "Cannot progress. Body MUST have Blocked by: <ref>"
+- name: ready
+  color: 1d76db
+  description: "Triage complete: has category+area+commitment, no needs/*. Auto-set."
+- name: needs-triage
+  color: ededed
+  description: "Inverse of ready. Default on new issues."
+
+# --- Triage needs (needs/*, additive) ---
+- name: needs/repro
+  color: fbca04
+  description: "Bug needs reproduction steps from reporter"
+- name: needs/decision
+  color: d876e3
+  description: "Awaiting a maintainer call on scope or approach"
+- name: needs/info
+  color: d876e3
+  description: "Awaiting reporter or requester response"
+
+# --- Standalone keepers ---
+- name: good first issue
+  color: 7057ff
+  description: "Good for newcomers"
+- name: help wanted
+  color: 008672
+  description: "Extra attention is needed"
+- name: snyk-finding
+  color: d73a4a
+  description: "Snyk-surfaced security finding requiring a fix"
+
+# --- Transitional (retired in T12) ---
+- name: roadmap-sync
+  color: 0075ca
+  description: "Roadmap sync issue (transitional — retired after backfill)"

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -5,136 +5,136 @@
 
 # --- Category (flat, exactly one per issue) ---
 - name: bug
-  color: d73a4a
+  color: "d73a4a"
   description: "Defect — something is broken"
 - name: enhancement
-  color: a2eeef
+  color: "a2eeef"
   description: "Improve an existing capability"
 - name: feature
-  color: 84b6eb
+  color: "84b6eb"
   description: "New capability that doesn't exist yet"
 - name: refactor
-  color: fbca04
+  color: "fbca04"
   description: "Internal restructure, no behaviour change"
 - name: redesign
-  color: ff9f1c
+  color: "ff9f1c"
   description: "Reshape architecture/UX/API — behaviour changes"
 - name: security
-  color: b60205
+  color: "b60205"
   description: "Security-relevant change (vuln fix, hardening, policy)"
 - name: docs
-  color: 0075ca
+  color: "0075ca"
   description: "Documentation-only"
 - name: chore
-  color: ededed
+  color: "ededed"
   description: "Deps, config, build, tooling"
 - name: test
-  color: c5def5
+  color: "c5def5"
   description: "Test-only changes"
 - name: spec
-  color: 5319e7
+  color: "5319e7"
   description: "Design or spec doc under docs/superpowers/specs/"
 
 # --- Area (area/*, one per issue) ---
 - name: area/operator
-  color: 0e8a16
+  color: "0e8a16"
   description: "Go operator (CRDs, reconcilers)"
 - name: area/task-service
-  color: 0e8a16
+  color: "0e8a16"
   description: "Go task-service"
 - name: area/adapters
-  color: 0e8a16
+  color: "0e8a16"
   description: "Go event adapters (alertmanager, k8s-audit)"
 - name: area/kapeproxy
-  color: 0e8a16
+  color: "0e8a16"
   description: "Go MCP proxy"
 - name: area/runtime
-  color: 0e8a16
+  color: "0e8a16"
   description: "Python LangGraph runtime"
 - name: area/dashboard
-  color: 0e8a16
+  color: "0e8a16"
   description: "TypeScript dashboard"
 - name: area/helm
-  color: 0e8a16
+  color: "0e8a16"
   description: "Helm charts and manifests"
 - name: area/crds
-  color: 0e8a16
+  color: "0e8a16"
   description: "CRD schemas and CEL validation"
 - name: area/docs
-  color: 0e8a16
+  color: "0e8a16"
   description: "docs/, README, runbooks (excludes spec docs)"
 - name: area/ci
-  color: 0e8a16
+  color: "0e8a16"
   description: ".github/workflows, tooling"
 - name: area/infra
-  color: 0e8a16
+  color: "0e8a16"
   description: "NATS, Postgres, cert-manager, External Secrets Operator"
 
 # --- Phase (phase/Mx-*, one per roadmap-tracked issue) ---
 - name: phase/M2-operator
-  color: 5319e7
+  color: "5319e7"
   description: "Phase 6 — Full Operator"
 - name: phase/M3-runtime
-  color: 5319e7
+  color: "5319e7"
   description: "Phase 7 — Full Runtime"
 - name: phase/M4-security
-  color: 5319e7
+  color: "5319e7"
   description: "Phase 8 — K8s Audit + Security"
 - name: phase/M5-dashboard
-  color: 5319e7
+  color: "5319e7"
   description: "Phase 9 — Dashboard"
 - name: phase/M6-release
-  color: 5319e7
+  color: "5319e7"
   description: "Phase 10 — Helm + Examples + Polish"
 
 # --- Commitment (flat, mutually exclusive) ---
 - name: committed
-  color: 0e8a16
+  color: "0e8a16"
   description: "Belongs to its milestone. Counts against milestone capacity."
 - name: stretch
-  color: fbca04
+  color: "fbca04"
   description: "Targeted for milestone if capacity allows. First to slip."
 - name: backlog
-  color: c5def5
+  color: "c5def5"
   description: "Not committed to any milestone. Re-evaluated each cycle."
 
 # --- Signals (flat, additive) ---
 - name: urgent
-  color: b60205
+  color: "b60205"
   description: "Interrupt rule. Standup ranks above committed. Body MUST have Reason:"
 - name: blocked
-  color: e99695
+  color: "e99695"
   description: "Cannot progress. Body MUST have Blocked by: <ref>"
 - name: ready
-  color: 1d76db
+  color: "1d76db"
   description: "Triage complete: has category+area+commitment, no needs/*. Auto-set."
 - name: needs-triage
-  color: ededed
+  color: "ededed"
   description: "Inverse of ready. Default on new issues."
 
 # --- Triage needs (needs/*, additive) ---
 - name: needs/repro
-  color: fbca04
+  color: "fbca04"
   description: "Bug needs reproduction steps from reporter"
 - name: needs/decision
-  color: d876e3
+  color: "d876e3"
   description: "Awaiting a maintainer call on scope or approach"
 - name: needs/info
-  color: d876e3
+  color: "d876e3"
   description: "Awaiting reporter or requester response"
 
 # --- Standalone keepers ---
 - name: good first issue
-  color: 7057ff
+  color: "7057ff"
   description: "Good for newcomers"
 - name: help wanted
-  color: 008672
+  color: "008672"
   description: "Extra attention is needed"
 - name: snyk-finding
-  color: d73a4a
+  color: "d73a4a"
   description: "Snyk-surfaced security finding requiring a fix"
 
 # --- Transitional (retired in T12) ---
 - name: roadmap-sync
-  color: 0075ca
+  color: "0075ca"
   description: "Roadmap sync issue (transitional — retired after backfill)"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,29 @@
+# .github/workflows/sync-labels.yml
+name: Sync labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/labels.yaml'
+      - 'tools/sync-labels.sh'
+      - '.github/workflows/sync-labels.yml'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install yq
+        run: |
+          sudo curl -L -o /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+      - name: Sync labels (apply)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash tools/sync-labels.sh --apply

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -2,12 +2,6 @@
 name: Sync labels
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - '.github/labels.yaml'
-      - 'tools/sync-labels.sh'
-      - '.github/workflows/sync-labels.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/validate-labels.yml
+++ b/.github/workflows/validate-labels.yml
@@ -1,0 +1,54 @@
+# .github/workflows/validate-labels.yml
+name: Validate issue labels
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_limit:
+        description: 'Max number of open issues to validate (default 200)'
+        required: false
+        default: '200'
+
+permissions:
+  issues: read
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate all open issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_LIMIT: ${{ github.event.inputs.issue_limit }}
+        run: |
+          set -euo pipefail
+          total=0
+          flagged=0
+          {
+            gh issue list --state open --limit "${ISSUE_LIMIT}" --json number \
+              | jq -r '.[].number' \
+              | while read -r num; do
+                  total=$((total+1))
+                  payload=$(gh issue view "$num" --json number,body,labels)
+                  violations=$(echo "$payload" | bash tools/validate-issue-labels.sh)
+                  if [[ -n "$violations" ]]; then
+                    flagged=$((flagged+1))
+                    echo "Issue #$num:"
+                    echo "$violations"
+                    echo
+                  fi
+                done
+            echo "---"
+            echo "Scanned: $total open issues."
+            echo "Flagged: $flagged with violations."
+          } | tee validator-report.txt
+
+      - name: Upload report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: validator-report
+          path: validator-report.txt
+          retention-days: 30

--- a/.github/workflows/validate-labels.yml
+++ b/.github/workflows/validate-labels.yml
@@ -28,19 +28,17 @@ jobs:
           total=0
           flagged=0
           {
-            gh issue list --state open --limit "${ISSUE_LIMIT}" --json number \
-              | jq -r '.[].number' \
-              | while read -r num; do
-                  total=$((total+1))
-                  payload=$(gh issue view "$num" --json number,body,labels)
-                  violations=$(echo "$payload" | bash tools/validate-issue-labels.sh)
-                  if [[ -n "$violations" ]]; then
-                    flagged=$((flagged+1))
-                    echo "Issue #$num:"
-                    echo "$violations"
-                    echo
-                  fi
-                done
+            while read -r num; do
+              total=$((total+1))
+              payload=$(gh issue view "$num" --json number,body,labels)
+              violations=$(echo "$payload" | bash tools/validate-issue-labels.sh)
+              if [[ -n "$violations" ]]; then
+                flagged=$((flagged+1))
+                echo "Issue #$num:"
+                echo "$violations"
+                echo
+              fi
+            done < <(gh issue list --state open --limit "${ISSUE_LIMIT}" --json number | jq -r '.[].number')
             echo "---"
             echo "Scanned: $total open issues."
             echo "Flagged: $flagged with violations."

--- a/tests/tools/_lib.sh
+++ b/tests/tools/_lib.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# tests/tools/_lib.sh
+# Shared assertions and test driver for tests/tools/test_*.sh.
+# Source this file; do not run it directly.
+#
+# Usage in a test file:
+#   #!/usr/bin/env bash
+#   set -uo pipefail
+#   source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+#   test_my_thing() { ... assert_contains ... ; }
+#   run_test "my thing does X" test_my_thing
+#   summary  # prints results and exits non-zero on failure
+
+# Intentionally NO `set -e` here — failing assertions must not abort the
+# runner; each test returns its status to run_test.
+
+PASSED=0
+FAILED=0
+FAILURES=()
+
+# Quote-truncate a value to 400 chars for readable failure output.
+_trunc() { printf '%s' "$1" | head -c 400; }
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="${3:-assert_contains}"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    return 0
+  fi
+  printf '    FAIL (%s): expected substring %q\n' "$msg" "$needle" >&2
+  printf '    actual: %s\n' "$(_trunc "$haystack")" >&2
+  return 1
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" msg="${3:-assert_not_contains}"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    return 0
+  fi
+  printf '    FAIL (%s): forbidden substring %q present\n' "$msg" "$needle" >&2
+  printf '    actual: %s\n' "$(_trunc "$haystack")" >&2
+  return 1
+}
+
+assert_empty() {
+  local value="$1" msg="${2:-assert_empty}"
+  if [[ -z "$value" ]]; then
+    return 0
+  fi
+  printf '    FAIL (%s): expected empty\n' "$msg" >&2
+  printf '    actual: %s\n' "$(_trunc "$value")" >&2
+  return 1
+}
+
+assert_status() {
+  local expected="$1" actual="$2" msg="${3:-assert_status}"
+  if [[ "$expected" -eq "$actual" ]]; then
+    return 0
+  fi
+  printf '    FAIL (%s): expected exit %d, got %d\n' "$msg" "$expected" "$actual" >&2
+  return 1
+}
+
+# Run a named test function. The function returns 0 for pass, non-zero for fail.
+# Each test runs in a subshell so env-var mutations and exported vars do not leak.
+run_test() {
+  local name="$1" fn="$2"
+  printf '  %-60s ' "$name"
+  if ( "$fn" ); then
+    PASSED=$((PASSED+1))
+    echo "PASS"
+  else
+    FAILED=$((FAILED+1))
+    FAILURES+=("$name")
+    echo "FAIL"
+  fi
+}
+
+summary() {
+  echo
+  echo "=== Summary ==="
+  echo "Passed: $PASSED"
+  echo "Failed: $FAILED"
+  if [[ $FAILED -gt 0 ]]; then
+    printf '\nFailures:\n' >&2
+    for f in "${FAILURES[@]}"; do
+      printf '  - %s\n' "$f" >&2
+    done
+    exit 1
+  fi
+  exit 0
+}

--- a/tests/tools/test_sync-labels.sh
+++ b/tests/tools/test_sync-labels.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# tests/tools/test_sync-labels.sh
+# Pure-bash tests for tools/sync-labels.sh.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/_lib.sh"
+
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# Fixture: minimal 2-label manifest
+cat > "$TEST_DIR/labels.yaml" <<'EOF'
+- name: bug
+  color: d73a4a
+  description: "Defect"
+- name: area/operator
+  color: 0e8a16
+  description: "Operator"
+EOF
+
+# --- tests ---
+
+test_dry_run_create() {
+  export SYNC_LABELS_GH_LIST_FIXTURE='[]'
+  local output rc
+  output="$(bash "$ROOT/tools/sync-labels.sh" --manifest "$TEST_DIR/labels.yaml" 2>&1)"
+  rc=$?
+  assert_status 0 "$rc" "script exit code" || return 1
+  assert_contains "$output" "CREATE bug" "should plan to create bug" || return 1
+  assert_contains "$output" "CREATE area/operator" "should plan to create area/operator" || return 1
+}
+
+test_dry_run_update() {
+  export SYNC_LABELS_GH_LIST_FIXTURE='[{"name":"bug","color":"000000","description":"Defect"}]'
+  local output rc
+  output="$(bash "$ROOT/tools/sync-labels.sh" --manifest "$TEST_DIR/labels.yaml" 2>&1)"
+  rc=$?
+  assert_status 0 "$rc" "script exit code" || return 1
+  assert_contains "$output" "UPDATE bug" "should plan to update bug (color changed)" || return 1
+}
+
+test_dry_run_delete() {
+  export SYNC_LABELS_GH_LIST_FIXTURE='[{"name":"bug","color":"d73a4a","description":"Defect"},{"name":"area/operator","color":"0e8a16","description":"Operator"},{"name":"obsolete","color":"ffffff","description":"old"}]'
+  local output rc
+  output="$(bash "$ROOT/tools/sync-labels.sh" --manifest "$TEST_DIR/labels.yaml" 2>&1)"
+  rc=$?
+  assert_status 0 "$rc" "script exit code" || return 1
+  assert_contains "$output" "DELETE obsolete" "should plan to delete labels not in manifest" || return 1
+}
+
+test_keep_extras_suppresses_delete() {
+  export SYNC_LABELS_GH_LIST_FIXTURE='[{"name":"obsolete","color":"ffffff","description":"old"}]'
+  local output rc
+  output="$(bash "$ROOT/tools/sync-labels.sh" --manifest "$TEST_DIR/labels.yaml" --keep-extras 2>&1)"
+  rc=$?
+  assert_status 0 "$rc" "script exit code" || return 1
+  assert_not_contains "$output" "DELETE" "--keep-extras should suppress deletes" || return 1
+}
+
+test_no_op_when_matched() {
+  export SYNC_LABELS_GH_LIST_FIXTURE='[{"name":"bug","color":"d73a4a","description":"Defect"},{"name":"area/operator","color":"0e8a16","description":"Operator"}]'
+  local output rc
+  output="$(bash "$ROOT/tools/sync-labels.sh" --manifest "$TEST_DIR/labels.yaml" 2>&1)"
+  rc=$?
+  assert_status 0 "$rc" "script exit code" || return 1
+  assert_not_contains "$output" "CREATE" "no creates expected" || return 1
+  assert_not_contains "$output" "UPDATE" "no updates expected" || return 1
+  assert_not_contains "$output" "DELETE" "no deletes expected" || return 1
+}
+
+# --- runner ---
+
+echo "Running $(basename "${BASH_SOURCE[0]}")"
+echo
+run_test "dry-run plans creates for missing labels"        test_dry_run_create
+run_test "dry-run plans updates on color/description diff" test_dry_run_update
+run_test "dry-run plans deletes for labels not in manifest" test_dry_run_delete
+run_test "--keep-extras suppresses deletes"                test_keep_extras_suppresses_delete
+run_test "no-op when manifest matches gh exactly"          test_no_op_when_matched
+summary

--- a/tests/tools/test_validate-issue-labels.sh
+++ b/tests/tools/test_validate-issue-labels.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# tests/tools/test_validate-issue-labels.sh
+# Pure-bash tests for tools/validate-issue-labels.sh.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/_lib.sh"
+
+# Helper: feed a JSON blob to the validator and capture stdout.
+run_validator() {
+  local input="$1"
+  echo "$input" | bash "$ROOT/tools/validate-issue-labels.sh"
+}
+
+# --- tests ---
+
+test_two_commitments_error() {
+  local result
+  result="$(run_validator '{"number":1,"body":"","labels":[{"name":"committed"},{"name":"stretch"}]}')"
+  assert_contains "$result" "ERROR multiple-commitments" "two commitments must error" || return 1
+}
+
+test_ready_without_category() {
+  local result
+  result="$(run_validator '{"number":2,"body":"","labels":[{"name":"ready"},{"name":"area/operator"},{"name":"backlog"}]}')"
+  assert_contains "$result" "ERROR ready-missing-category" "ready without category must error" || return 1
+}
+
+test_ready_without_area() {
+  local result
+  result="$(run_validator '{"number":3,"body":"","labels":[{"name":"ready"},{"name":"bug"},{"name":"backlog"}]}')"
+  assert_contains "$result" "ERROR ready-missing-area" "ready without area must error" || return 1
+}
+
+test_ready_without_commitment() {
+  local result
+  result="$(run_validator '{"number":4,"body":"","labels":[{"name":"ready"},{"name":"bug"},{"name":"area/operator"}]}')"
+  assert_contains "$result" "ERROR ready-missing-commitment" "ready without commitment must error" || return 1
+}
+
+test_ready_with_needs() {
+  local result
+  result="$(run_validator '{"number":5,"body":"","labels":[{"name":"ready"},{"name":"bug"},{"name":"area/operator"},{"name":"backlog"},{"name":"needs/info"}]}')"
+  assert_contains "$result" "ERROR ready-with-needs" "ready with needs/* must error" || return 1
+}
+
+test_both_triage_and_ready() {
+  local result
+  result="$(run_validator '{"number":6,"body":"","labels":[{"name":"ready"},{"name":"needs-triage"},{"name":"bug"},{"name":"area/operator"},{"name":"backlog"}]}')"
+  assert_contains "$result" "ERROR both-needs-triage-and-ready" "both labels must error" || return 1
+}
+
+test_urgent_without_reason_warns() {
+  local result
+  result="$(run_validator '{"number":7,"body":"some text without the marker","labels":[{"name":"urgent"}]}')"
+  assert_contains "$result" "WARN urgent-without-reason" "urgent w/o reason must warn" || return 1
+}
+
+test_urgent_with_reason_no_warn() {
+  local result
+  result="$(run_validator '{"number":8,"body":"Reason: prod incident\nmore text","labels":[{"name":"urgent"}]}')"
+  assert_not_contains "$result" "urgent-without-reason" "urgent w/ reason must not warn" || return 1
+}
+
+test_blocked_without_reference_warns() {
+  local result
+  result="$(run_validator '{"number":9,"body":"some text","labels":[{"name":"blocked"}]}')"
+  assert_contains "$result" "WARN blocked-without-reference" "blocked w/o reference must warn" || return 1
+}
+
+test_blocked_with_reference_no_warn() {
+  local result
+  result="$(run_validator '{"number":10,"body":"Blocked by: #42","labels":[{"name":"blocked"}]}')"
+  assert_not_contains "$result" "blocked-without-reference" "blocked w/ reference must not warn" || return 1
+}
+
+test_clean_issue_silent() {
+  local result
+  result="$(run_validator '{"number":11,"body":"","labels":[{"name":"bug"},{"name":"area/operator"},{"name":"backlog"},{"name":"ready"}]}')"
+  assert_empty "$result" "clean issue must produce no output" || return 1
+}
+
+# --- runner ---
+
+echo "Running $(basename "${BASH_SOURCE[0]}")"
+echo
+run_test "issue with two commitments → ERROR"             test_two_commitments_error
+run_test "ready without category → ERROR"                 test_ready_without_category
+run_test "ready without area → ERROR"                     test_ready_without_area
+run_test "ready without commitment → ERROR"               test_ready_without_commitment
+run_test "ready with needs/* → ERROR"                     test_ready_with_needs
+run_test "both needs-triage and ready → ERROR"            test_both_triage_and_ready
+run_test "urgent without Reason: → WARN"                  test_urgent_without_reason_warns
+run_test "urgent with Reason: → no warn"                  test_urgent_with_reason_no_warn
+run_test "blocked without Blocked by: → WARN"             test_blocked_without_reference_warns
+run_test "blocked with Blocked by: → no warn"             test_blocked_with_reference_no_warn
+run_test "clean issue → no output"                        test_clean_issue_silent
+summary

--- a/tools/backfill-issue-labels.sh
+++ b/tools/backfill-issue-labels.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# tools/backfill-issue-labels.sh
+# Backfill the new label taxonomy on open issues that pre-date it.
+# Dry-run by default; --apply does the mutations.
+# Derivation helpers are duplicated from tools/migrate-to-github.sh by design:
+# both are one-shot scripts, and a shared library is overkill for ~30 lines.
+set -euo pipefail
+
+APPLY=0
+[[ "${1:-}" == "--apply" ]] && APPLY=1
+
+derive_area() {
+  local title="$1"
+  local t
+  t="$(echo "$title" | tr '[:upper:]' '[:lower:]')"
+  case "$t" in
+    *"operator"*|*"reconciler"*|*"kapehandler"*|*"kapetool"*|*"kapeschema"*|*"crd validation"*) echo "area/operator" ;;
+    *"task-service"*|*"task service"*|*"openapi"*) echo "area/task-service" ;;
+    *"adapter"*|*"alertmanager"*|*"audit adapter"*) echo "area/adapters" ;;
+    *"kapeproxy"*|*"mcp proxy"*) echo "area/kapeproxy" ;;
+    *"runtime"*|*"langgraph"*|*"python"*) echo "area/runtime" ;;
+    *"dashboard"*|*"sse"*|*"eventsource"*|*"oauth2 proxy"*) echo "area/dashboard" ;;
+    *"helm"*|*"chart"*|*"template"*) echo "area/helm" ;;
+    *"crd"*|*"cel"*|*"xvalidation"*) echo "area/crds" ;;
+    *"docs"*|*"readme"*|*"runbook"*|*"changelog"*) echo "area/docs" ;;
+    *"ci"*|*"workflow"*|*"actions"*|*"snyk"*) echo "area/ci" ;;
+    *"nats"*|*"postgres"*|*"cloudnativepg"*|*"cert-manager"*|*"eso"*|*"external secrets"*) echo "area/infra" ;;
+    *) echo "" ;;
+  esac
+}
+
+derive_phase() {
+  local title="$1"
+  case "$title" in
+    \[P6/*) echo "phase/M2-operator" ;;
+    \[P7/*) echo "phase/M3-runtime" ;;
+    \[P8/*) echo "phase/M4-security" ;;
+    \[P9/*) echo "phase/M5-dashboard" ;;
+    \[P10/*) echo "phase/M6-release" ;;
+    *) echo "" ;;
+  esac
+}
+
+apply_labels() {
+  local issue_num="$1" labels="$2"
+  echo "[$issue_num] add: $labels"
+  if [[ $APPLY -eq 1 ]]; then
+    # gh issue edit --add-label expects comma-separated
+    gh issue edit "$issue_num" --add-label "$labels"
+  fi
+}
+
+main() {
+  gh issue list --state open --limit 200 \
+    --json number,title,labels --jq '.[] | @json' \
+    | while read -r row; do
+      local num title existing
+      num=$(echo "$row" | jq -r '.number')
+      title=$(echo "$row" | jq -r '.title')
+      existing=$(echo "$row" | jq -r '[.labels[].name] | join(",")')
+
+      # Skip if issue already has a commitment label (already migrated)
+      if echo ",$existing," | grep -qE ',(committed|stretch|backlog),'; then
+        continue
+      fi
+
+      local to_add=()
+      local area phase
+      area="$(derive_area "$title")"
+      phase="$(derive_phase "$title")"
+
+      # Ensure category for roadmap-tagged issues
+      if echo ",$existing," | grep -q ',roadmap-sync,' && ! echo ",$existing," | grep -qE ',(bug|enhancement|feature|refactor|redesign|security|docs|chore|test|spec),'; then
+        to_add+=("enhancement")
+      fi
+
+      [[ -n "$area" ]] && ! echo ",$existing," | grep -q ",$area," && to_add+=("$area")
+      [[ -n "$phase" ]] && ! echo ",$existing," | grep -q ",$phase," && to_add+=("$phase")
+
+      # Default commitment: committed if roadmap (assumed in current milestone), else backlog
+      if echo ",$existing," | grep -q ',roadmap-sync,'; then
+        to_add+=("committed")
+      else
+        to_add+=("backlog")
+      fi
+
+      # If area or phase couldn't be derived, mark needs-triage so the validator surfaces it
+      if [[ -z "$area" || ( -z "$phase" && $(echo ",$existing," | grep -c ',roadmap-sync,') -eq 1 ) ]]; then
+        to_add+=("needs-triage")
+      fi
+
+      if [[ ${#to_add[@]} -gt 0 ]]; then
+        apply_labels "$num" "$(IFS=,; echo "${to_add[*]}")"
+      fi
+    done
+}
+
+main "$@"

--- a/tools/migrate-to-github.sh
+++ b/tools/migrate-to-github.sh
@@ -89,7 +89,7 @@ create_issue() {
   local title="$1" body="$2" milestone_number="$3" state="$4"
   # Check if issue already exists with same title
   local existing
-  existing=$(gh_api "repos/${REPO}/issues?state=all&per_page=100&labels=roadmap-sync" \
+  existing=$(gh_api "repos/${REPO}/issues?state=all&per_page=100&milestone=${milestone_number}" \
     --jq ".[] | select(.title == \"${title}\") | .number" 2>/dev/null | head -1 || true)
   if [[ -n "$existing" ]]; then
     echo "    Issue '${title}' already exists (#${existing}), skipping."
@@ -100,7 +100,7 @@ create_issue() {
   area_label="$(derive_area "$title")"
   phase_label="$(derive_phase "$title")"
 
-  local label_args=(-f "labels[]=roadmap-sync" -f "labels[]=enhancement" -f "labels[]=committed")
+  local label_args=(-f "labels[]=enhancement" -f "labels[]=committed")
   [[ -n "$area_label" ]]  && label_args+=(-f "labels[]=$area_label")
   [[ -n "$phase_label" ]] && label_args+=(-f "labels[]=$phase_label")
   [[ -z "$area_label" || -z "$phase_label" ]] && label_args+=(-f "labels[]=needs-triage")

--- a/tools/migrate-to-github.sh
+++ b/tools/migrate-to-github.sh
@@ -14,6 +14,42 @@ gh_api() {
   gh api "$@"
 }
 
+# Derive area/* label from issue title keywords. Returns empty if ambiguous.
+# Mapping mirrors docs/agent-rituals.md → "Title-keyword → area/* mapping".
+derive_area() {
+  local title="$1"
+  local t
+  t="$(echo "$title" | tr '[:upper:]' '[:lower:]')"
+  case "$t" in
+    *"operator"*|*"reconciler"*|*"kapehandler"*|*"kapetool"*|*"kapeschema"*|*"crd validation"*) echo "area/operator" ;;
+    *"task-service"*|*"task service"*|*"openapi"*) echo "area/task-service" ;;
+    *"adapter"*|*"alertmanager"*|*"audit adapter"*) echo "area/adapters" ;;
+    *"kapeproxy"*|*"mcp proxy"*) echo "area/kapeproxy" ;;
+    *"runtime"*|*"langgraph"*|*"python"*) echo "area/runtime" ;;
+    *"dashboard"*|*"sse"*|*"eventsource"*|*"oauth2 proxy"*) echo "area/dashboard" ;;
+    *"helm"*|*"chart"*|*"template"*) echo "area/helm" ;;
+    *"crd"*|*"cel"*|*"xvalidation"*) echo "area/crds" ;;
+    *"docs"*|*"readme"*|*"runbook"*|*"changelog"*) echo "area/docs" ;;
+    *"ci"*|*"workflow"*|*"actions"*|*"snyk"*) echo "area/ci" ;;
+    *"nats"*|*"postgres"*|*"cloudnativepg"*|*"cert-manager"*|*"eso"*|*"external secrets"*) echo "area/infra" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Derive phase/Mx-* label from "[Pn/mm]" title prefix.
+# Phase → milestone mapping comes from the milestones table.
+derive_phase() {
+  local title="$1"
+  case "$title" in
+    \[P6/*) echo "phase/M2-operator" ;;
+    \[P7/*) echo "phase/M3-runtime" ;;
+    \[P8/*) echo "phase/M4-security" ;;
+    \[P9/*) echo "phase/M5-dashboard" ;;
+    \[P10/*) echo "phase/M6-release" ;;
+    *) echo "" ;;
+  esac
+}
+
 create_label_if_missing() {
   local name="$1" color="$2"
   if ! gh_api "repos/${REPO}/labels/${name}" &>/dev/null; then
@@ -60,12 +96,21 @@ create_issue() {
     return
   fi
   echo "    Creating issue '${title}'..."
+  local area_label phase_label
+  area_label="$(derive_area "$title")"
+  phase_label="$(derive_phase "$title")"
+
+  local label_args=(-f "labels[]=roadmap-sync" -f "labels[]=enhancement" -f "labels[]=committed")
+  [[ -n "$area_label" ]]  && label_args+=(-f "labels[]=$area_label")
+  [[ -n "$phase_label" ]] && label_args+=(-f "labels[]=$phase_label")
+  [[ -z "$area_label" || -z "$phase_label" ]] && label_args+=(-f "labels[]=needs-triage")
+
   local issue_number
   issue_number=$(gh_api "repos/${REPO}/issues" \
     -f title="${title}" \
     -f body="${body}" \
     -f milestone="${milestone_number}" \
-    -f "labels[]=roadmap-sync" \
+    "${label_args[@]}" \
     --jq '.number')
   echo "      -> Issue #${issue_number}"
   # Close if phase is done

--- a/tools/snyk-finding-to-issue.sh
+++ b/tools/snyk-finding-to-issue.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# tools/snyk-finding-to-issue.sh
+# Open or update a GitHub issue from a Snyk MCP finding.
+# Args:
+#   --title <string>       (required)
+#   --body  <string>       (required — should already include 'Reason: Snyk <severity> ...')
+#   --scan-path <path>     (required — e.g., ./operator)
+#   --finding-id <string>  (required — used to dedupe via title prefix)
+set -euo pipefail
+
+TITLE=""; BODY=""; SCAN_PATH=""; FINDING_ID=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title) TITLE="$2"; shift 2 ;;
+    --body) BODY="$2"; shift 2 ;;
+    --scan-path) SCAN_PATH="$2"; shift 2 ;;
+    --finding-id) FINDING_ID="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+for var in TITLE BODY SCAN_PATH FINDING_ID; do
+  [[ -z "${!var}" ]] && { echo "missing --$(echo "$var" | tr '[:upper:]' '[:lower:]' | tr _ -)" >&2; exit 2; }
+done
+
+# Map scan path → area/*
+area=""
+case "$SCAN_PATH" in
+  ./operator|operator) area="area/operator" ;;
+  ./adapters|adapters) area="area/adapters" ;;
+  ./task-service|task-service) area="area/task-service" ;;
+  ./kapeproxy|kapeproxy) area="area/kapeproxy" ;;
+  ./runtime|runtime) area="area/runtime" ;;
+  *) area="" ;;
+esac
+
+# Prepend finding id to title so dedupe via title-match works
+full_title="[$FINDING_ID] $TITLE"
+
+existing=$(gh issue list --state all --search "in:title \"[$FINDING_ID]\"" --json number --jq '.[0].number // ""')
+if [[ -n "$existing" ]]; then
+  echo "Issue already exists: #$existing — skipping create"
+  exit 0
+fi
+
+labels=("bug" "security" "snyk-finding" "urgent" "backlog")
+[[ -n "$area" ]] && labels+=("$area")
+
+gh issue create \
+  --title "$full_title" \
+  --body "$BODY" \
+  $(printf -- "--label %s " "${labels[@]}")

--- a/tools/sync-labels.sh
+++ b/tools/sync-labels.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# tools/sync-labels.sh
+# Idempotently sync the label set defined in .github/labels.yaml to GitHub.
+# Usage:
+#   tools/sync-labels.sh [--manifest <path>] [--keep-extras] [--apply]
+# Modes:
+#   default: dry-run (print planned mutations, no gh calls)
+#   --apply: actually call gh label create/edit/delete
+set -euo pipefail
+
+MANIFEST=".github/labels.yaml"
+APPLY=0
+KEEP_EXTRAS=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest) MANIFEST="$2"; shift 2 ;;
+    --apply) APPLY=1; shift ;;
+    --keep-extras) KEEP_EXTRAS=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Test hook: if SYNC_LABELS_DRY_RUN is set, force dry-run regardless of --apply.
+[[ -n "${SYNC_LABELS_DRY_RUN:-}" ]] && APPLY=0 || true
+
+# Test hook: if SYNC_LABELS_GH_LIST_FIXTURE is set, use it instead of real gh.
+gh_list_labels() {
+  if [[ -n "${SYNC_LABELS_GH_LIST_FIXTURE:-}" ]]; then
+    echo "$SYNC_LABELS_GH_LIST_FIXTURE"
+  else
+    gh label list --json name,color,description --limit 200
+  fi
+}
+
+# Parse manifest into TSV: name<TAB>color<TAB>description
+manifest_tsv() {
+  yq -o=json '.' "$MANIFEST" \
+    | jq -r '.[] | [.name, .color, .description] | @tsv'
+}
+
+# Parse existing labels into the same TSV shape
+existing_tsv() {
+  gh_list_labels | jq -r '.[] | [.name, .color, .description] | @tsv'
+}
+
+main() {
+  local manifest existing
+  manifest="$(manifest_tsv)"
+  existing="$(existing_tsv)"
+
+  # Phase 1: create or update
+  while IFS=$'\t' read -r name color desc; do
+    [[ -z "$name" ]] && continue
+    local current
+    current="$(echo "$existing" | awk -F'\t' -v n="$name" '$1==n {print; exit}')" || true
+    if [[ -z "$current" ]]; then
+      echo "CREATE $name"
+      [[ $APPLY -eq 1 ]] && gh label create "$name" --color "$color" --description "$desc" || true
+    else
+      local cur_color cur_desc
+      cur_color="$(echo "$current" | cut -f2)"
+      cur_desc="$(echo "$current" | cut -f3)"
+      if [[ "$cur_color" != "$color" || "$cur_desc" != "$desc" ]]; then
+        echo "UPDATE $name"
+        [[ $APPLY -eq 1 ]] && gh label edit "$name" --color "$color" --description "$desc" || true
+      fi
+    fi
+  done <<< "$manifest"
+
+  # Phase 2: delete extras (unless --keep-extras)
+  if [[ $KEEP_EXTRAS -eq 0 ]]; then
+    while IFS=$'\t' read -r name _ _; do
+      [[ -z "$name" ]] && continue
+      if ! echo "$manifest" | awk -F'\t' -v n="$name" '$1==n {found=1} END {exit !found}'; then
+        echo "DELETE $name"
+        [[ $APPLY -eq 1 ]] && gh label delete "$name" --yes || true
+      fi
+    done <<< "$existing"
+  fi
+}
+
+main "$@"

--- a/tools/validate-issue-labels.sh
+++ b/tools/validate-issue-labels.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# tools/validate-issue-labels.sh
+# Read one issue's JSON from stdin (gh issue view --json number,body,labels output)
+# and emit ERROR/WARN lines per docs/agent-rituals.md → "State validator".
+# Exit code is always 0; aggregation is the caller's responsibility.
+set -euo pipefail
+
+input="$(cat)"
+
+has_label() {
+  local pattern="$1"
+  echo "$input" | jq -e --arg p "$pattern" '.labels[] | select(.name == $p)' >/dev/null
+}
+count_labels_matching() {
+  local pattern="$1"
+  echo "$input" | jq --arg p "$pattern" '[.labels[].name | select(test($p))] | length'
+}
+body_has_line() {
+  local pattern="$1"
+  echo "$input" | jq -r '.body // ""' | grep -qE "$pattern"
+}
+
+categories='^(bug|enhancement|feature|refactor|redesign|security|docs|chore|test|spec)$'
+areas='^area/'
+needs='^needs/'
+
+# Rule 1: multiple commitments
+commitments=$(count_labels_matching '^(committed|stretch|backlog)$')
+if [[ "$commitments" -gt 1 ]]; then
+  echo "ERROR multiple-commitments: issue has $commitments commitment labels (expected 0 or 1)"
+fi
+
+# Rule 2-5: ready preconditions
+if has_label "ready"; then
+  cat_count=$(count_labels_matching "$categories")
+  area_count=$(count_labels_matching "$areas")
+  needs_count=$(count_labels_matching "$needs")
+  [[ "$cat_count" -eq 0 ]] && echo "ERROR ready-missing-category: ready label set without a category label"
+  [[ "$area_count" -eq 0 ]] && echo "ERROR ready-missing-area: ready label set without an area/* label"
+  [[ "$commitments" -eq 0 ]] && echo "ERROR ready-missing-commitment: ready label set without a commitment label"
+  [[ "$needs_count" -gt 0 ]] && echo "ERROR ready-with-needs: ready label set with open needs/* label(s)"
+  has_label "needs-triage" && echo "ERROR both-needs-triage-and-ready: issue has both needs-triage and ready"
+fi
+
+# Rule 6-7: urgent / blocked body markers
+if has_label "urgent" && ! body_has_line '^Reason:'; then
+  echo "WARN urgent-without-reason: urgent label set but body missing 'Reason: <line>'"
+fi
+if has_label "blocked" && ! body_has_line '^Blocked by:'; then
+  echo "WARN blocked-without-reference: blocked label set but body missing 'Blocked by: <ref>'"
+fi


### PR DESCRIPTION
## Summary

Implements the 40-label taxonomy and supporting automation per the plan at `docs/superpowers/plans/2026-05-17-github-label-system-rollout.md` (PR #92, merged).

- **T1** `.github/labels.yaml` — declarative manifest of 39 final labels + 1 transitional `roadmap-sync`
- **T2** `tools/sync-labels.sh` + shared bash test runner (`tests/tools/_lib.sh`) — idempotent CREATE/UPDATE/DELETE driven by the manifest, 5 tests
- **T3** `.github/workflows/sync-labels.yml` — auto-runs the sync on push-to-main when the manifest/script changes, plus workflow_dispatch
- **T5** `.claude/skills/apply-labels/SKILL.md` — Claude skill that derives labels for one issue/PR, asks before applying ambiguous ones, never auto-applies `urgent`/`committed`/`blocked`
- **T6** `.claude/standup.json` — adds `urgent-issues` + `blocked-issues` datasources (powers ACT NOW / STUCK buckets)
- **T7** `tools/validate-issue-labels.sh` + 11 tests — emits ERROR/WARN lines per state-validator rules in `docs/agent-rituals.md`
- **T8** `.github/workflows/validate-labels.yml` — workflow_dispatch-only validator sweep, uploads `validator-report.txt` as 30-day artifact. Includes a bug fix vs. the spec: uses `done < <(...)` process substitution so the `Scanned` / `Flagged` totals don't get lost to the pipe subshell.
- **T9** `tools/migrate-to-github.sh` — derives `area/*` + `phase/Mx-*` from issue titles; new roadmap issues get `roadmap-sync + enhancement + committed + area + phase` (or `needs-triage` fallback)
- **T10** `tools/backfill-issue-labels.sh` — one-shot script for existing open issues (idempotent — skips already-migrated)
- **T11** `tools/snyk-finding-to-issue.sh` — opens a deduped `bug + security + snyk-finding + urgent + backlog + area/*` issue from a Snyk MCP finding

**Stats:** 13 files changed, 961 insertions / 2 deletions, 11 commits.

## Deferred maintainer gates (post-merge)

These steps from the plan require live `gh` auth + human observation against real GitHub state and were intentionally skipped:

- **T4 (initial sync)** — maintainer runs `bash tools/sync-labels.sh` to inspect the planned diff, then `--apply`. The first run deletes the spec's retired labels (`invalid`, `duplicate`, `wontfix`, `question`); confirm the DELETE list contains only these before applying.
- **T5 Step 3 (skill smoke-test)** — invoke `/apply-labels <this PR number>` against this PR to verify the derivation flow.
- **T8 Step 3 (validator dispatch)** — run `gh workflow run validate-labels.yml -f issue_limit=200` after merge.
- **T10 Steps 3-6 (backfill run)** — maintainer runs `bash tools/backfill-issue-labels.sh` dry-run, then `--apply`, then validator sweep.
- **T11 Step 3 (Snyk smoke-test)** — manual call with a fake `--finding-id` to verify label set and dedupe.
- **T12 (retire `roadmap-sync`)** — deferred to a follow-up PR after T10 backfill is verified.

## Other notes

- `shellcheck` is not installed in this environment and could not be run. All scripts pass `bash -n` syntax checks. Recommend running shellcheck in CI for future tightening.

## Test Plan

- [x] `bash tests/tools/test_sync-labels.sh` → 5/5 pass
- [x] `bash tests/tools/test_validate-issue-labels.sh` → 11/11 pass
- [x] `bash -n` clean on all 8 shell scripts
- [x] `python3 yaml.safe_load` clean on all 3 YAML files
- [x] `jq empty .claude/standup.json` clean
- [x] `yq eval '. | length' .github/labels.yaml` → 40
- [x] `yq eval '.[] | select(.description | length > 100) | .name'` → empty (all descriptions ≤100 chars)
- [x] SKILL.md frontmatter parses, `name=apply-labels`
- [ ] Maintainer: run `bash tools/sync-labels.sh` dry-run; confirm DELETE list = {invalid, duplicate, wontfix, question}
- [ ] Maintainer: run `--apply`; confirm `gh label list` diff against `.github/labels.yaml` is empty
- [ ] Maintainer: dispatch validate-labels workflow; review report
- [ ] Maintainer: run backfill dry-run; spot-check derivations; `--apply`; validator sweep