### PR TITLE
docs(kapeproxy): spec + plan for slice-7 fixup

### DIFF
--- a/docs/superpowers/plans/2026-05-17-kapeproxy-slice7-fixup.md
+++ b/docs/superpowers/plans/2026-05-17-kapeproxy-slice7-fixup.md
@@ -18,8 +18,8 @@
 
 | File | Action | Purpose |
 |---|---|---|
-| `kapeproxy/internal/proxy/router.go` | Modify | Rewrite `List()` and `Route()` to use glob-intersect with `path.Match` |
-| `kapeproxy/internal/proxy/router_test.go` | Modify | Replace `TestRouter_NamespacedNames_WithAllowlist` + `TestRouter_UnavailableUpstream_StillExposesNames`; add new glob-intersect tests |
+| `kapeproxy/internal/proxy/router.go` | Modify | Rewrite `List()` and `Route()` for deny-by-default glob-intersect with `path.Match` (D16+D20); update doc comments |
+| `kapeproxy/internal/proxy/router_test.go` | Modify | Replace `TestRouter_NamespacedNames_WithAllowlist` + `TestRouter_UnavailableUpstream_StillExposesNames`; add deny-by-default tests (`TestRouterList_NilAllowlistExposesNothing`, `TestRouterList_EmptyAllowlistExposesNothing`, `TestRouterList_StarAllowlistExposesAll`, `TestRouterRoute_NilAllowlistDenies`, `TestRouterRoute_StarAllowlistAllows`) and glob-intersect tests |
 
 **operator module — modified**
 
@@ -80,16 +80,97 @@ Expected: all three return matches. If any do not match, somebody has fixed part
 
 ---
 
-## Task 1: Tools filter — red tests (glob-intersect)
+## Task 1: Tools filter — red tests (deny-by-default glob-intersect)
 
 **Files:**
 - Modify: `kapeproxy/internal/proxy/router_test.go`
 
-The existing tests in `router_test.go` accidentally encode the wrong rule. `TestRouter_NamespacedNames_WithAllowlist` asserts that an allowlist of `["query_dashboards", "get_alert"]` exposes those two names whether or not the upstream has them — which is the bug. `TestRouter_UnavailableUpstream_StillExposesNames` asserts the allowlist is the source of truth even when the upstream is unreachable — also the wrong rule under D16.
+The existing tests in `router_test.go` accidentally encode the wrong rule. `TestRouter_NamespacedNames_WithAllowlist` asserts that an allowlist of `["query_dashboards", "get_alert"]` exposes those two names whether or not the upstream has them — which is the bug. `TestRouter_UnavailableUpstream_StillExposesNames` asserts the allowlist is the source of truth even when the upstream is unreachable — also the wrong rule under D16. The shipped code additionally treats a nil/empty allowlist as "expose all" (the old D14 semantics), which D20 now flips.
 
-This task adds the two new tests that pin the corrected vision, and updates the two misaligned existing tests so they assert the new contract. Run before any code change; both new and updated tests must fail before Task 2.
+This task adds the tests that pin the corrected D16+D20 contract — deny-by-default for nil/empty, glob-intersect for populated, `["*"]` as the explicit opt-in to expose all — and updates the misaligned existing tests so they assert the new contract. Run before any code change; both new and updated tests must fail before Task 2.
 
-- [ ] **Step 1: Add `TestRouterList_GlobIntersectsUpstream`**
+- [ ] **Step 1: Add deny-by-default `List()` tests (D20)**
+
+In `kapeproxy/internal/proxy/router_test.go`, add:
+
+```go
+func TestRouterList_NilAllowlistExposesNothing(t *testing.T) {
+	// D20: nil allowedTools is deny-by-default — the upstream contributes nothing.
+	cfg := &proxy.Config{
+		Upstreams: map[string]*proxy.UpstreamConfig{
+			"up": {
+				URL: "http://up:8080", Transport: "streamable-http",
+				AllowedTools: nil,
+			},
+		},
+	}
+	ups := map[string]proxy.Upstream{
+		"up": &fakeUpstream{
+			name:  "up",
+			tools: []string{"k8s_get_pods", "k8s_list_namespaces", "helm_install"},
+			avail: true,
+		},
+	}
+	r := proxy.NewRouter(cfg, ups)
+
+	assert.Empty(t, r.List(),
+		"D20: nil allowedTools exposes zero tools (deny-by-default), regardless of what the upstream advertises")
+}
+
+func TestRouterList_EmptyAllowlistExposesNothing(t *testing.T) {
+	// D20: an explicitly-empty allowedTools slice is equivalent to nil.
+	// (The config parser already normalises [] → nil per kapeproxy/internal/proxy/config.go;
+	// implementer: verify that normalisation still applies, and if so this test exercises the
+	// normalised form. If config.go does NOT normalise, this test pins the runtime behaviour
+	// for both shapes directly.)
+	cfg := &proxy.Config{
+		Upstreams: map[string]*proxy.UpstreamConfig{
+			"up": {
+				URL: "http://up:8080", Transport: "streamable-http",
+				AllowedTools: []string{},
+			},
+		},
+	}
+	ups := map[string]proxy.Upstream{
+		"up": &fakeUpstream{
+			name:  "up",
+			tools: []string{"k8s_get_pods", "helm_install"},
+			avail: true,
+		},
+	}
+	r := proxy.NewRouter(cfg, ups)
+
+	assert.Empty(t, r.List(),
+		"D20: empty allowedTools slice exposes zero tools (deny-by-default)")
+}
+
+func TestRouterList_StarAllowlistExposesAll(t *testing.T) {
+	// D20 escape hatch: ["*"] is the explicit opt-in to expose every upstream tool.
+	cfg := &proxy.Config{
+		Upstreams: map[string]*proxy.UpstreamConfig{
+			"up": {
+				URL: "http://up:8080", Transport: "streamable-http",
+				AllowedTools: []string{"*"},
+			},
+		},
+	}
+	ups := map[string]proxy.Upstream{
+		"up": &fakeUpstream{
+			name:  "up",
+			tools: []string{"k8s_get_pods", "k8s_list_namespaces", "helm_install"},
+			avail: true,
+		},
+	}
+	r := proxy.NewRouter(cfg, ups)
+
+	assert.ElementsMatch(t,
+		[]string{"up__k8s_get_pods", "up__k8s_list_namespaces", "up__helm_install"},
+		r.List(),
+		"D20: [\"*\"] is the legacy 'expose all' opt-in; matches every flat tool name")
+}
+```
+
+- [ ] **Step 2: Add `TestRouterList_GlobIntersectsUpstream`**
 
 In `kapeproxy/internal/proxy/router_test.go`, add:
 
@@ -145,7 +226,65 @@ func TestRouterList_ExactNameNotOnUpstream_Dropped(t *testing.T) {
 }
 ```
 
-- [ ] **Step 2: Add `TestRouterRoute_GlobIntersectsUpstream`**
+- [ ] **Step 3: Add deny-by-default `Route()` tests (D20)**
+
+```go
+func TestRouterRoute_NilAllowlistDenies(t *testing.T) {
+	// D20: nil allowedTools → tools/call is rejected for every namespaced name from this upstream.
+	// The router returns (nil, false); the JSON-RPC server translates that into MCP error -32601.
+	cfg := &proxy.Config{
+		Upstreams: map[string]*proxy.UpstreamConfig{
+			"up": {
+				URL: "http://up:8080", Transport: "streamable-http",
+				AllowedTools: nil,
+			},
+		},
+	}
+	ups := map[string]proxy.Upstream{
+		"up": &fakeUpstream{
+			name:  "up",
+			tools: []string{"k8s_get_pods", "helm_install"},
+			avail: true,
+		},
+	}
+	r := proxy.NewRouter(cfg, ups)
+
+	_, ok := r.Route("up__k8s_get_pods")
+	assert.False(t, ok, "D20: nil allowedTools denies tools/call even when upstream has the tool")
+	_, ok = r.Route("up__anything")
+	assert.False(t, ok, "D20: nil allowedTools denies tools/call for every name on this upstream")
+}
+
+func TestRouterRoute_StarAllowlistAllows(t *testing.T) {
+	// D20 escape hatch: ["*"] allows every upstream tool through Route() as well as List().
+	cfg := &proxy.Config{
+		Upstreams: map[string]*proxy.UpstreamConfig{
+			"up": {
+				URL: "http://up:8080", Transport: "streamable-http",
+				AllowedTools: []string{"*"},
+			},
+		},
+	}
+	ups := map[string]proxy.Upstream{
+		"up": &fakeUpstream{
+			name:  "up",
+			tools: []string{"k8s_get_pods", "helm_install"},
+			avail: true,
+		},
+	}
+	r := proxy.NewRouter(cfg, ups)
+
+	e, ok := r.Route("up__k8s_get_pods")
+	require.True(t, ok)
+	assert.Equal(t, "k8s_get_pods", e.OriginalName)
+
+	e, ok = r.Route("up__helm_install")
+	require.True(t, ok)
+	assert.Equal(t, "helm_install", e.OriginalName)
+}
+```
+
+- [ ] **Step 4: Add `TestRouterRoute_GlobIntersectsUpstream`**
 
 ```go
 func TestRouterRoute_GlobIntersectsUpstream(t *testing.T) {
@@ -200,13 +339,13 @@ func TestRouterRoute_MalformedGlob_DoesNotPanic(t *testing.T) {
 }
 ```
 
-- [ ] **Step 3: Update `TestRouter_NamespacedNames_WithAllowlist`**
+- [ ] **Step 5: Update `TestRouter_NamespacedNames_WithAllowlist`**
 
 The existing test asserts `delete_dashboard` is filtered out — that part stays correct. But it relied on the literal-emit behaviour to pass with an upstream that advertised the allowed names verbatim. Re-read the test; if the upstream's `tools` already contains every allowlist entry (it does: `["query_dashboards", "get_alert", "delete_dashboard"]`), the test passes under the new rule too — no change needed beyond verifying it after Task 2.
 
-- [ ] **Step 4: Update `TestRouter_UnavailableUpstream_StillExposesNames`**
+- [ ] **Step 6: Update `TestRouter_UnavailableUpstream_StillExposesNames`**
 
-Under D16 this test's assertion is wrong. An unavailable upstream returns an empty `ListTools()`, so the intersection is empty. Rename and rewrite:
+Under D16+D20 this test's assertion is wrong. An unavailable upstream returns an empty `ListTools()`, so the intersection is empty (and a nil allowlist would also produce empty by D20). Rename and rewrite:
 
 ```go
 func TestRouter_UnavailableUpstream_ExposesNothing(t *testing.T) {
@@ -233,36 +372,41 @@ func TestRouter_UnavailableUpstream_ExposesNothing(t *testing.T) {
 }
 ```
 
-- [ ] **Step 5: Run the tests; confirm they fail**
+- [ ] **Step 7: Run the tests; confirm they fail**
 
 ```bash
-cd <wt>/kapeproxy && go test ./internal/proxy/... -run TestRouter -v 2>&1 | tail -50
+cd <wt>/kapeproxy && go test ./internal/proxy/... -run TestRouter -v 2>&1 | tail -80
 ```
 
-Expected:
-- `TestRouterList_GlobIntersectsUpstream` FAILS — current `List()` emits the allowlist verbatim, so `up__helm_install` is missing (good) but `helm_install` isn't in the allowlist either, so this might pass by coincidence. Verify by adding a glob entry that the current code can't possibly handle: `k8s_*` is not in `upstream.ListTools()`, so the current code emits `up__k8s_*` literally and the test fails on the namespacing.
+Expected against the PR #57 implementation (which emits the allowlist verbatim and treats nil as "expose all"):
+- `TestRouterList_NilAllowlistExposesNothing` FAILS — current code treats nil as expose-all, so the upstream's three tools are emitted instead of zero.
+- `TestRouterList_EmptyAllowlistExposesNothing` FAILS — same reason (current code's "empty == expose all" branch).
+- `TestRouterList_StarAllowlistExposesAll` FAILS — current code emits `up__*` literally (verbatim from the allowlist), not the three real tool names.
+- `TestRouterList_GlobIntersectsUpstream` FAILS — current code emits `up__k8s_*` literally.
 - `TestRouterList_ExactNameNotOnUpstream_Dropped` FAILS — current code emits `up__nonexistent` verbatim.
+- `TestRouterRoute_NilAllowlistDenies` FAILS — current `Route()` treats nil allowlist as "allow anything namespaced to this upstream"; the call succeeds instead of being rejected.
+- `TestRouterRoute_StarAllowlistAllows` FAILS — current `Route()` does string-equality with the allowlist, so it looks for the literal `*` and rejects real tool names.
 - `TestRouterRoute_GlobIntersectsUpstream` FAILS — current `Route()` does string-equality with allowlist (not glob) and does not consult `upstream.ListTools()`.
 - `TestRouterRoute_MalformedGlob_DoesNotPanic` PASSES coincidentally (current code never calls `path.Match`); will still pass after Task 2 — the assertion is what matters.
 - `TestRouter_UnavailableUpstream_ExposesNothing` FAILS — current code emits `down-mcp__foo` verbatim from the allowlist.
 
 If any of these unexpectedly pass, re-read the current `router.go` and revise the test to actually pin the new rule.
 
-- [ ] **Step 6: Commit the red tests**
+- [ ] **Step 8: Commit the red tests**
 
 ```bash
 git -C <wt> add kapeproxy/internal/proxy/router_test.go
-git -C <wt> commit -m "test(kapeproxy/router): pin glob-intersect tools-filter semantics (failing)"
+git -C <wt> commit -m "test(kapeproxy/router): pin deny-by-default glob-intersect semantics (failing)"
 ```
 
 ---
 
-## Task 2: Tools filter — green code (glob-intersect)
+## Task 2: Tools filter — green code (deny-by-default glob-intersect)
 
 **Files:**
 - Modify: `kapeproxy/internal/proxy/router.go`
 
-Rewrite `List()` and `Route()` so both consult the upstream's real tool list and apply glob-matching against `allowedTools`. Add a small helper that validates patterns once at construction and logs malformed ones, so the per-call path never reports `ErrBadPattern`.
+Rewrite `List()` and `Route()` so both consult the upstream's real tool list and apply glob-matching against `allowedTools` with deny-by-default for the empty case. Add a small helper that validates patterns once at construction and logs malformed ones, so the per-call path never reports `ErrBadPattern`. Update the doc comments on `List()` and `Route()` to state the deny-by-default semantic explicitly (D16 + D20).
 
 - [ ] **Step 1: Validate globs at construction**
 
@@ -305,9 +449,17 @@ func matchesAny(patterns []string, tool string) bool {
 }
 ```
 
-- [ ] **Step 3: Rewrite `List()`**
+- [ ] **Step 3: Rewrite `List()` (deny-by-default)**
 
 ```go
+// List returns every namespaced tool name exposed by this proxy.
+//
+// D16+D20: for each upstream, the exposed set is the intersection of
+// upstream.ListTools() with the union of path.Match() globs in
+// allowedTools. A nil or empty allowedTools is the empty set of globs,
+// which matches nothing — the upstream contributes zero tools
+// (deny-by-default). Operators opt into "expose all" by writing
+// allowedTools: ["*"].
 func (r *Router) List() []string {
 	var out []string
 	for upName, upCfg := range r.cfg.Upstreams {
@@ -315,8 +467,12 @@ func (r *Router) List() []string {
 		if !ok {
 			continue
 		}
+		// D20: empty allowlist denies everything from this upstream.
+		if len(upCfg.AllowedTools) == 0 {
+			continue
+		}
 		for _, t := range up.ListTools() {
-			if upCfg.AllowedTools == nil || matchesAny(upCfg.AllowedTools, t) {
+			if matchesAny(upCfg.AllowedTools, t) {
 				out = append(out, Namespace(upName, t))
 			}
 		}
@@ -325,11 +481,25 @@ func (r *Router) List() []string {
 }
 ```
 
-Key differences from PR #57: enumerates `up.ListTools()` first (so the upstream is the source of truth), then filters by glob match. The `nil` case still exposes everything — D14 unchanged.
+Key differences from PR #57: enumerates `up.ListTools()` first (so the upstream is the source of truth), filters by glob match, and treats nil/empty `allowedTools` as deny-all (D20) rather than expose-all (D14, superseded).
 
-- [ ] **Step 4: Rewrite `Route()`**
+- [ ] **Step 4: Rewrite `Route()` (deny-by-default)**
 
 ```go
+// Route resolves a namespaced tool name (e.g. "k8s__get_pods") to the
+// upstream entry that should handle it.
+//
+// D16+D20: returns (nil, false) — which the JSON-RPC server surfaces as
+// MCP error -32601 (method not found) — when any of the following hold:
+//   - the prefix matches no configured upstream
+//   - the upstream is not in the upstreams map
+//   - the upstream's allowedTools is nil or empty (deny-by-default per D20)
+//   - the original tool name is not on upstream.ListTools()
+//   - no path.Match glob in allowedTools matches the original name
+//
+// Both Route() and List() compute the same exposed set; a name advertised
+// by List() must be acceptable to Route() (when the upstream is healthy)
+// and vice versa.
 func (r *Router) Route(namespaced string) (*Entry, bool) {
 	for upName, upCfg := range r.cfg.Upstreams {
 		prefix := upName + NamespaceSeparator
@@ -341,11 +511,15 @@ func (r *Router) Route(namespaced string) (*Entry, bool) {
 		if !ok {
 			return nil, false
 		}
-		// D16: original must exist on upstream AND match at least one glob (or allowlist == nil).
+		// D20: empty allowlist denies every call to this upstream.
+		if len(upCfg.AllowedTools) == 0 {
+			return nil, false
+		}
+		// D16: original must exist on upstream AND match at least one glob.
 		if !contains(up.ListTools(), original) {
 			return nil, false
 		}
-		if upCfg.AllowedTools != nil && !matchesAny(upCfg.AllowedTools, original) {
+		if !matchesAny(upCfg.AllowedTools, original) {
 			return nil, false
 		}
 		audit := true
@@ -363,7 +537,7 @@ func (r *Router) Route(namespaced string) (*Entry, bool) {
 }
 ```
 
-(The existing `contains` helper stays as-is — used here for the upstream membership check.)
+(The existing `contains` helper stays as-is — used here for the upstream membership check.) The JSON-RPC server already maps `Route() → (nil, false)` to MCP error `-32601`; no change to the server is required for D20 — the existing rejection path is the rejection path D20 specifies.
 
 - [ ] **Step 5: Add the `path` and `strings` imports**
 
@@ -388,10 +562,10 @@ Expected: every `TestRouter*` test passes, including the four added in Task 1 an
 
 ```bash
 git -C <wt> add kapeproxy/internal/proxy/router.go
-git -C <wt> commit -m "feat(kapeproxy/router)!: allowedTools is a glob list intersected with upstream.ListTools (D16)"
+git -C <wt> commit -m "feat(kapeproxy/router)!: allowedTools is deny-by-default; glob-intersect upstream.ListTools (D16+D20)"
 ```
 
-The `!` marks the semantic-change scope per the spec (§4); the behaviour is backward-compatible for exact-name allowlists but the contract narrowed.
+The `!` marks the breaking change per the spec (§4, §7): KapeTools with empty or omitted `allowedTools` will now expose nothing instead of everything. Exact-name allowlists remain backward-compatible; the empty/omitted case is the breaking shift.
 
 ---
 
@@ -577,6 +751,30 @@ If `helm/templates/` updates were needed, add them to the same commit.
 
 ---
 
+## Task 5b: Operator-side coverage for the D20 contract (optional, recommended)
+
+**Files (optional):**
+- Modify: `operator/internal/controller/kapehandler_controller_test.go` (or wherever the envtest scenarios live)
+
+**Goal:** add light-touch operator-side coverage that the D20 contract holds end-to-end through `renderKapeproxyConfig` → kapeproxy. The operator's render path itself does **not** need to change — it can continue to omit `allowedTools` from the rendered `kapeproxy-config` YAML when the KapeTool's `spec.mcp.allowedTools` is empty, because kapeproxy now interprets that omission as deny-all (the new safe default). Existing `renderKapeproxyConfig` golden tests therefore stay green; no golden file updates are required.
+
+This task adds **one** envtest scenario asserting the happy path of the new contract:
+
+- [ ] **Step 1: Envtest — KapeTool with `allowedTools: ["k8s_*"]` exposes only matching tools**
+
+Add a test that creates a `KapeHandler` + `KapeTool` with `spec.mcp.allowedTools: ["k8s_*"]`, asserts the handler reconciles to `KapeProxyConfigured`, and (using an in-process stub upstream that advertises `k8s_get_pods` and `helm_install`) asserts that a `tools/list` call against kapeproxy returns only `<up>__k8s_get_pods`. The exact name of the test and the stub upstream wiring follow the existing slice-7 envtest scaffolding — implementer reuses whatever pattern is already in the operator's envtest suite.
+
+If wiring a live kapeproxy into the operator envtest would balloon scope, this task is **optional but recommended**: skip it and rely on the kapeproxy router tests from Task 1 to pin the contract. Flag in the PR description if skipped.
+
+- [ ] **Step 2 (only if Step 1 was done): Commit**
+
+```bash
+git -C <wt> add operator/internal/controller/kapehandler_controller_test.go
+git -C <wt> commit -m "test(operator/envtest): assert D20 allowedTools glob intersection via kapeproxy"
+```
+
+---
+
 ## Task 6: Remove the stub CI workflow
 
 **Files:**
@@ -630,26 +828,42 @@ Prepend a note (do not delete the historical text — it explains why the PR #57
 > **Superseded 2026-05-17 by [`docs/superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md`](../../../../superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md) §3.A / D16.** The rule below is the *original* slice-7 plan; the corrected rule is glob-intersect with `upstream.ListTools()`. Implementation lives under `docs/superpowers/plans/2026-05-17-kapeproxy-slice7-fixup.md`.
 ```
 
-- [ ] **Step 2: Extend IMPLEMENTATION-SPEC's decision log**
+- [ ] **Step 2: Extend IMPLEMENTATION-SPEC's decision log and supersede D14**
 
-Open `docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md`. After the D15 row in the Decision Log table (around line 485), add:
+Open `docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md`. First, mark D14 (line 484) as superseded — annotate in place rather than deleting, so the history stays legible:
 
 ```markdown
-| D16 | `allowedTools` is a glob-pattern list (`path.Match`) intersected with `upstream.ListTools()`; both `tools/list` and `tools/call` agree on the same exposed set | Original D14 only defined the `nil` case; the populated case was filled in wrong by the slice-7 plan. See [2026-05-17-kapeproxy-slice7-fixup spec](../../../superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md) §3.A |
+| D14 | ~~`allowedTools: []` means "expose all" — field omitted from kapeproxy-config when empty~~ **(SUPERSEDED 2026-05-17 by D20 in [2026-05-17-kapeproxy-slice7-fixup spec](../../../superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md): empty/omitted now means deny-all)** | Matches existing kapetool sidecar behaviour |
+```
+
+Then, after the D15 row, add:
+
+```markdown
+| D16 | `allowedTools` is a deny-by-default glob-pattern list (`path.Match`) intersected with `upstream.ListTools()`; both `tools/list` and `tools/call` agree on the same exposed set | Original D14 only defined the empty case (as "expose all", now superseded); the populated case was filled in wrong by the slice-7 plan. See [2026-05-17-kapeproxy-slice7-fixup spec](../../../superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md) §3.A |
 | D17 | Operator in-code default for `kapeproxy` image version is `latest`; release pins live in `helm/values.yaml` | Spec §2.1 already mandates `latest`; release-coupling does not belong in Go. See fixup spec §3.B |
 | D18 | Playground and Tilt build/reference `kape/kapeproxy:local` (unversioned local-dev tag) | Decouple dev tooling from release versions. See fixup spec §3.B |
 | D19 | The slice-5 stub binary and `.github/workflows/kapeproxy-stub.yml` are both removed in the fixup (completes slice-7 Task 12) | Time-bounding the stub per D2 + R1. See fixup spec §3.C |
+| D20 | **Supersedes D14.** `allowedTools` is deny-by-default — `nil`/omitted/`[]` exposes zero tools; `["*"]` is the explicit opt-in to expose all. Applies uniformly to `tools/list` (omit) and `tools/call` (reject with MCP `-32601`) | Security posture for an audited proxy: operator must opt in, not opt out. Migration: existing KapeTools relying on D14's "omit means expose all" must add `allowedTools: ["*"]` (or, preferred, a minimum-privilege allowlist). See fixup spec §5/D20 and §7 |
 ```
 
-(If the implementer prefers a single "See fixup spec for D16–D19" row instead of four full rows, that is acceptable — the fixup spec is the canonical source.)
+(If the implementer prefers a single "See fixup spec for D16–D20" row instead of five full rows, that is acceptable — the fixup spec is the canonical source. The D14 strike-through must stay either way.)
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 3: Sweep for other D14 references**
+
+```bash
+grep -rn "\bD14\b" <wt>/docs/
+```
+
+Expected matches: only the IMPLEMENTATION-SPEC row (now annotated as superseded) and the fixup spec/plan files (which reference D14 in the context of explaining the supersession). If `grep` finds any other doc that cites D14 as a live rule (e.g. a runbook, an operator guide, the slice-7 plan's body), add a one-line forward-reference there too: "(D14 superseded by D20; see fixup spec)." Report the list of files touched in the PR description.
+
+- [ ] **Step 4: Commit**
 
 ```bash
 git -C <wt> add \
   docs/roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md \
   docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md
-git -C <wt> commit -m "docs(phase6): annotate slice-7 plan supersession; add D16–D19 to decision log"
+# plus any additional docs found in Step 3
+git -C <wt> commit -m "docs(phase6): supersede D14; add D16–D20 to decision log; annotate slice-7 plan"
 ```
 
 ---
@@ -705,14 +919,16 @@ Expected: `OK`.
 
 Paste this into the implementation PR's description and tick each item before merge:
 
-- [ ] `cd kapeproxy && go test ./...` — all green, including the new `TestRouterList_GlobIntersectsUpstream`, `TestRouterList_ExactNameNotOnUpstream_Dropped`, `TestRouterRoute_GlobIntersectsUpstream`, `TestRouterRoute_MalformedGlob_DoesNotPanic`, and rewritten `TestRouter_UnavailableUpstream_ExposesNothing`.
+- [ ] `cd kapeproxy && go test ./...` — all green, including the new `TestRouterList_NilAllowlistExposesNothing`, `TestRouterList_EmptyAllowlistExposesNothing`, `TestRouterList_StarAllowlistExposesAll`, `TestRouterList_GlobIntersectsUpstream`, `TestRouterList_ExactNameNotOnUpstream_Dropped`, `TestRouterRoute_NilAllowlistDenies`, `TestRouterRoute_StarAllowlistAllows`, `TestRouterRoute_GlobIntersectsUpstream`, `TestRouterRoute_MalformedGlob_DoesNotPanic`, and rewritten `TestRouter_UnavailableUpstream_ExposesNothing`.
 - [ ] `cd operator && go test ./...` — all green, including the new `TestKapeproxyImageRef_DefaultIsLatest` and `TestKapeproxyImageRef_WithDefaults_IsLatest`.
 - [ ] `tools/list` and `tools/call` agree on the same exposed set (covered by router tests above; verified end-to-end if the slice-7 integration test was updated).
+- [ ] **D20 contract:** no namespaced tool appears in `tools/list` unless its un-namespaced name is in `upstream.ListTools()` AND matches a glob in `allowedTools` (router tests above).
+- [ ] **D20 contract:** a KapeTool with no `spec.mcp.allowedTools` exposes nothing via kapeproxy (validated by the optional envtest in Task 5b, or by the kapeproxy router tests if Task 5b was skipped — note which in the PR description).
 - [ ] `helm template helm/` renders without error and the rendered output references `kape/kapeproxy:0.7.0` (sourced from `values.yaml`).
 - [ ] `git grep "kape/kapeproxy:0.7.0"` returns matches only inside `helm/values.yaml` and `docs/`.
 - [ ] `git grep "kape/kapeproxy:stub\|kapeproxy:stub-"` returns matches only inside `docs/`.
 - [ ] `.github/workflows/kapeproxy-stub.yml` no longer exists.
 - [ ] Playground stack (`podman compose build kapeproxy`) and Tilt (`tilt up`) both build/reference `kape/kapeproxy:local` — manual verification noted in PR description.
 - [ ] `docs/roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md:381` carries the supersession note linking to the fixup spec.
-- [ ] `docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md` decision log includes D16–D19 (or a single forward-reference to the fixup spec).
+- [ ] `docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md` decision log includes D16–D20 (or a single forward-reference to the fixup spec) and D14 is annotated as superseded by D20.
 - [ ] SBOM ritual from `kape-io/CLAUDE.md` run on `./adapters`, `./operator`, `./task-service`, `./kapeproxy` (this is a code-touching PR — the spec/plan PR does not need it, but the implementation PR does).

--- a/docs/superpowers/plans/2026-05-17-kapeproxy-slice7-fixup.md
+++ b/docs/superpowers/plans/2026-05-17-kapeproxy-slice7-fixup.md
@@ -1,0 +1,718 @@
+# kapeproxy Slice 7 Fixup — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Each task follows red-test → green-code → verify per superpowers:test-driven-development.
+
+**Goal:** Apply the corrections described in [`docs/superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md`](../specs/2026-05-17-kapeproxy-slice7-fixup.md) on top of PR #57's `feat/phase6-slice7-kapeproxy-binary` branch — glob-intersect tools filter, `latest` / `:local` / chart-pin image defaults, plus completing slice-7 Tasks 12 and 14.
+
+**Architecture:** Two Go edits (`kapeproxy/internal/proxy/router.go`, `operator/domain/config/config.go`), three YAML/file edits (playground compose, Tiltfile, helm values), one workflow deletion, and two docs touch-ups. No new packages, no new module dependencies beyond stdlib `path`.
+
+**Tech Stack:** Go 1.25 (kapeproxy module), Go 1.24 (operator module), stdlib `path.Match`, existing test deps (`testify`, zerolog).
+
+**Worktree:** Implementer should branch from PR #57's branch (`feat/phase6-slice7-kapeproxy-binary`) into a fresh worktree, e.g. `.worktrees/feat-kapeproxy-slice7-fixup`, so the fixup can land as a follow-up commit / push on the same PR — or as a stacked PR if PR #57 has already merged by then. The exact worktree path is implementer's choice; all commands below use `<wt>` as a stand-in.
+
+---
+
+## File Map
+
+**kapeproxy module — modified**
+
+| File | Action | Purpose |
+|---|---|---|
+| `kapeproxy/internal/proxy/router.go` | Modify | Rewrite `List()` and `Route()` to use glob-intersect with `path.Match` |
+| `kapeproxy/internal/proxy/router_test.go` | Modify | Replace `TestRouter_NamespacedNames_WithAllowlist` + `TestRouter_UnavailableUpstream_StillExposesNames`; add new glob-intersect tests |
+
+**operator module — modified**
+
+| File | Action | Purpose |
+|---|---|---|
+| `operator/domain/config/config.go` | Modify | `KapeproxyImageRef()` default `"0.7.0"` → `"latest"`; `WithDefaults()` `"stub"` → `"latest"` |
+| `operator/domain/config/config_test.go` | Create/Modify | Assert `KapeproxyImageRef()` returns `kape/kapeproxy:latest` when no override |
+
+**playground / Tilt — modified**
+
+| File | Action | Purpose |
+|---|---|---|
+| `playground/docker-compose.playground.yml` | Modify | Line 44: `kape/kapeproxy:0.7.0` → `kape/kapeproxy:local` |
+| `playground/Tiltfile` | Modify | Lines 21, 26: `kape/kapeproxy:0.7.0` → `kape/kapeproxy:local` |
+
+**helm chart — modified**
+
+| File | Action | Purpose |
+|---|---|---|
+| `helm/values.yaml` | Modify | Add `kapeproxy:` block with `image: { repository, tag, pullPolicy }` |
+| `helm/templates/operator/*` | Read-only check | Verify nothing currently consumes the values; wire if it does |
+
+**CI workflows — removed**
+
+| File | Action | Purpose |
+|---|---|---|
+| `.github/workflows/kapeproxy-stub.yml` | Delete | Stub binary is gone (slice-7 Task 12); its workflow goes with it |
+
+**docs — modified**
+
+| File | Action | Purpose |
+|---|---|---|
+| `docs/roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md` | Modify | Line 381: add a note that the rule is superseded; link to fixup spec |
+| `docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md` | Modify | Append D16–D19 referring to the fixup spec as source of truth |
+
+---
+
+## Pre-flight
+
+- [ ] **Step 1: Confirm worktree branched from the right base**
+
+```bash
+git -C <wt> status
+git -C <wt> log --oneline -5
+```
+
+Expected: clean tree, HEAD is on or descended from `feat/phase6-slice7-kapeproxy-binary` (or `main` if PR #57 has merged — in that case rebase this fixup branch on `origin/main` before continuing).
+
+- [ ] **Step 2: Confirm the divergences are still present**
+
+```bash
+git -C <wt> grep -n "kape/kapeproxy:0.7.0" -- playground/
+git -C <wt> grep -n "\"0.7.0\"\|\"stub\"" -- operator/domain/config/config.go
+git -C <wt> ls .github/workflows/kapeproxy-stub.yml
+```
+
+Expected: all three return matches. If any do not match, somebody has fixed part of this already — stop and reconcile before proceeding (re-read the fixup spec and trim the relevant task).
+
+---
+
+## Task 1: Tools filter — red tests (glob-intersect)
+
+**Files:**
+- Modify: `kapeproxy/internal/proxy/router_test.go`
+
+The existing tests in `router_test.go` accidentally encode the wrong rule. `TestRouter_NamespacedNames_WithAllowlist` asserts that an allowlist of `["query_dashboards", "get_alert"]` exposes those two names whether or not the upstream has them — which is the bug. `TestRouter_UnavailableUpstream_StillExposesNames` asserts the allowlist is the source of truth even when the upstream is unreachable — also the wrong rule under D16.
+
+This task adds the two new tests that pin the corrected vision, and updates the two misaligned existing tests so they assert the new contract. Run before any code change; both new and updated tests must fail before Task 2.
+
+- [ ] **Step 1: Add `TestRouterList_GlobIntersectsUpstream`**
+
+In `kapeproxy/internal/proxy/router_test.go`, add:
+
+```go
+func TestRouterList_GlobIntersectsUpstream(t *testing.T) {
+	cfg := &proxy.Config{
+		Upstreams: map[string]*proxy.UpstreamConfig{
+			"up": {
+				URL: "http://up:8080", Transport: "streamable-http",
+				AllowedTools: []string{"k8s_*"},
+			},
+		},
+	}
+	ups := map[string]proxy.Upstream{
+		"up": &fakeUpstream{
+			name:  "up",
+			tools: []string{"k8s_get_pods", "k8s_list_namespaces", "helm_install"},
+			avail: true,
+		},
+	}
+	r := proxy.NewRouter(cfg, ups)
+
+	assert.ElementsMatch(t,
+		[]string{"up__k8s_get_pods", "up__k8s_list_namespaces"},
+		r.List(),
+		"only k8s_* tools that the upstream actually advertises should be exposed",
+	)
+}
+
+func TestRouterList_ExactNameNotOnUpstream_Dropped(t *testing.T) {
+	cfg := &proxy.Config{
+		Upstreams: map[string]*proxy.UpstreamConfig{
+			"up": {
+				URL: "http://up:8080", Transport: "sse",
+				AllowedTools: []string{"k8s_get_pods", "nonexistent"},
+			},
+		},
+	}
+	ups := map[string]proxy.Upstream{
+		"up": &fakeUpstream{
+			name:  "up",
+			tools: []string{"k8s_get_pods", "k8s_list_namespaces", "helm_install"},
+			avail: true,
+		},
+	}
+	r := proxy.NewRouter(cfg, ups)
+
+	assert.ElementsMatch(t,
+		[]string{"up__k8s_get_pods"},
+		r.List(),
+		"exact-name allowlist entries that don't match any upstream tool are silently dropped",
+	)
+}
+```
+
+- [ ] **Step 2: Add `TestRouterRoute_GlobIntersectsUpstream`**
+
+```go
+func TestRouterRoute_GlobIntersectsUpstream(t *testing.T) {
+	cfg := &proxy.Config{
+		Upstreams: map[string]*proxy.UpstreamConfig{
+			"up": {
+				URL: "http://up:8080", Transport: "streamable-http",
+				AllowedTools: []string{"k8s_*"},
+			},
+		},
+	}
+	ups := map[string]proxy.Upstream{
+		"up": &fakeUpstream{
+			name:  "up",
+			tools: []string{"k8s_get_pods", "k8s_list_namespaces", "helm_install"},
+			avail: true,
+		},
+	}
+	r := proxy.NewRouter(cfg, ups)
+
+	// Matches glob AND exists on upstream → routable.
+	e, ok := r.Route("up__k8s_get_pods")
+	require.True(t, ok)
+	assert.Equal(t, "k8s_get_pods", e.OriginalName)
+
+	// Exists on upstream but does NOT match any glob → not routable.
+	_, ok = r.Route("up__helm_install")
+	assert.False(t, ok, "helm_install is on the upstream but no glob matches it")
+
+	// Matches glob (vacuously) but does NOT exist on upstream → not routable.
+	_, ok = r.Route("up__k8s_nonexistent")
+	assert.False(t, ok, "k8s_nonexistent matches k8s_* but is not on the upstream")
+}
+
+func TestRouterRoute_MalformedGlob_DoesNotPanic(t *testing.T) {
+	// path.Match returns ErrBadPattern for an unterminated character class.
+	cfg := &proxy.Config{
+		Upstreams: map[string]*proxy.UpstreamConfig{
+			"up": {
+				URL: "http://up:8080", Transport: "sse",
+				AllowedTools: []string{"[bad"},
+			},
+		},
+	}
+	ups := map[string]proxy.Upstream{
+		"up": &fakeUpstream{name: "up", tools: []string{"anything"}, avail: true},
+	}
+	r := proxy.NewRouter(cfg, ups)
+	assert.Empty(t, r.List(), "malformed glob matches nothing; router must not panic")
+	_, ok := r.Route("up__anything")
+	assert.False(t, ok)
+}
+```
+
+- [ ] **Step 3: Update `TestRouter_NamespacedNames_WithAllowlist`**
+
+The existing test asserts `delete_dashboard` is filtered out — that part stays correct. But it relied on the literal-emit behaviour to pass with an upstream that advertised the allowed names verbatim. Re-read the test; if the upstream's `tools` already contains every allowlist entry (it does: `["query_dashboards", "get_alert", "delete_dashboard"]`), the test passes under the new rule too — no change needed beyond verifying it after Task 2.
+
+- [ ] **Step 4: Update `TestRouter_UnavailableUpstream_StillExposesNames`**
+
+Under D16 this test's assertion is wrong. An unavailable upstream returns an empty `ListTools()`, so the intersection is empty. Rename and rewrite:
+
+```go
+func TestRouter_UnavailableUpstream_ExposesNothing(t *testing.T) {
+	// Under D16, the exposed set is intersection(upstream.ListTools, globs).
+	// An unreachable upstream has ListTools() == nil, so nothing can be exposed
+	// regardless of what's in allowedTools. tools/call on those names will
+	// likewise fail at Route() (not at upstream call-time).
+	cfg := &proxy.Config{
+		Upstreams: map[string]*proxy.UpstreamConfig{
+			"down-mcp": {
+				URL: "http://down:8080", Transport: "sse",
+				AllowedTools: []string{"foo"},
+			},
+		},
+	}
+	ups := map[string]proxy.Upstream{
+		"down-mcp": &fakeUpstream{name: "down-mcp", tools: nil, avail: false},
+	}
+	r := proxy.NewRouter(cfg, ups)
+	assert.Empty(t, r.List(),
+		"D16: unreachable upstream → empty ListTools → empty intersection → nothing exposed")
+	_, ok := r.Route("down-mcp__foo")
+	assert.False(t, ok)
+}
+```
+
+- [ ] **Step 5: Run the tests; confirm they fail**
+
+```bash
+cd <wt>/kapeproxy && go test ./internal/proxy/... -run TestRouter -v 2>&1 | tail -50
+```
+
+Expected:
+- `TestRouterList_GlobIntersectsUpstream` FAILS — current `List()` emits the allowlist verbatim, so `up__helm_install` is missing (good) but `helm_install` isn't in the allowlist either, so this might pass by coincidence. Verify by adding a glob entry that the current code can't possibly handle: `k8s_*` is not in `upstream.ListTools()`, so the current code emits `up__k8s_*` literally and the test fails on the namespacing.
+- `TestRouterList_ExactNameNotOnUpstream_Dropped` FAILS — current code emits `up__nonexistent` verbatim.
+- `TestRouterRoute_GlobIntersectsUpstream` FAILS — current `Route()` does string-equality with allowlist (not glob) and does not consult `upstream.ListTools()`.
+- `TestRouterRoute_MalformedGlob_DoesNotPanic` PASSES coincidentally (current code never calls `path.Match`); will still pass after Task 2 — the assertion is what matters.
+- `TestRouter_UnavailableUpstream_ExposesNothing` FAILS — current code emits `down-mcp__foo` verbatim from the allowlist.
+
+If any of these unexpectedly pass, re-read the current `router.go` and revise the test to actually pin the new rule.
+
+- [ ] **Step 6: Commit the red tests**
+
+```bash
+git -C <wt> add kapeproxy/internal/proxy/router_test.go
+git -C <wt> commit -m "test(kapeproxy/router): pin glob-intersect tools-filter semantics (failing)"
+```
+
+---
+
+## Task 2: Tools filter — green code (glob-intersect)
+
+**Files:**
+- Modify: `kapeproxy/internal/proxy/router.go`
+
+Rewrite `List()` and `Route()` so both consult the upstream's real tool list and apply glob-matching against `allowedTools`. Add a small helper that validates patterns once at construction and logs malformed ones, so the per-call path never reports `ErrBadPattern`.
+
+- [ ] **Step 1: Validate globs at construction**
+
+In `NewRouter`, after building the receiver, iterate every `upCfg.AllowedTools` entry and call `path.Match(p, "")` (or any non-empty dummy) to detect `ErrBadPattern`. On error, emit a single zerolog warn-level line per malformed pattern (`router.glob_pattern_invalid` with fields `upstream`, `pattern`, `error`) and remember the pattern so the per-call hot path can skip it cheaply. Suggested shape:
+
+```go
+// router.go (illustrative)
+func NewRouter(cfg *Config, upstreams map[string]Upstream) *Router {
+	r := &Router{cfg: cfg, upstreams: upstreams}
+	for upName, upCfg := range cfg.Upstreams {
+		for _, p := range upCfg.AllowedTools {
+			if _, err := path.Match(p, ""); err != nil {
+				log.Warn().
+					Str("upstream", upName).
+					Str("pattern", p).
+					Err(err).
+					Msg("router.glob_pattern_invalid; treating as match-nothing")
+			}
+		}
+	}
+	return r
+}
+```
+
+(Implementer's choice whether to filter the bad patterns out of the slice or skip them inline in `matchesAny`. The latter is simpler and keeps the config structure intact for debugging.)
+
+- [ ] **Step 2: Add a `matchesAny` helper**
+
+```go
+// matchesAny reports whether tool matches any of the glob patterns.
+// Patterns that produce ErrBadPattern are skipped silently (already logged at startup).
+func matchesAny(patterns []string, tool string) bool {
+	for _, p := range patterns {
+		ok, err := path.Match(p, tool)
+		if err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 3: Rewrite `List()`**
+
+```go
+func (r *Router) List() []string {
+	var out []string
+	for upName, upCfg := range r.cfg.Upstreams {
+		up, ok := r.upstreams[upName]
+		if !ok {
+			continue
+		}
+		for _, t := range up.ListTools() {
+			if upCfg.AllowedTools == nil || matchesAny(upCfg.AllowedTools, t) {
+				out = append(out, Namespace(upName, t))
+			}
+		}
+	}
+	return out
+}
+```
+
+Key differences from PR #57: enumerates `up.ListTools()` first (so the upstream is the source of truth), then filters by glob match. The `nil` case still exposes everything — D14 unchanged.
+
+- [ ] **Step 4: Rewrite `Route()`**
+
+```go
+func (r *Router) Route(namespaced string) (*Entry, bool) {
+	for upName, upCfg := range r.cfg.Upstreams {
+		prefix := upName + NamespaceSeparator
+		if !strings.HasPrefix(namespaced, prefix) {
+			continue
+		}
+		original := namespaced[len(prefix):]
+		up, ok := r.upstreams[upName]
+		if !ok {
+			return nil, false
+		}
+		// D16: original must exist on upstream AND match at least one glob (or allowlist == nil).
+		if !contains(up.ListTools(), original) {
+			return nil, false
+		}
+		if upCfg.AllowedTools != nil && !matchesAny(upCfg.AllowedTools, original) {
+			return nil, false
+		}
+		audit := true
+		if upCfg.Audit != nil {
+			audit = *upCfg.Audit
+		}
+		return &Entry{
+			Upstream:     up,
+			OriginalName: original,
+			Redaction:    upCfg.Redaction,
+			Audit:        audit,
+		}, true
+	}
+	return nil, false
+}
+```
+
+(The existing `contains` helper stays as-is — used here for the upstream membership check.)
+
+- [ ] **Step 5: Add the `path` and `strings` imports**
+
+```go
+import (
+	"path"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+```
+
+- [ ] **Step 6: Run the tests; confirm green**
+
+```bash
+cd <wt>/kapeproxy && go test ./internal/proxy/... -v 2>&1 | tail -60
+```
+
+Expected: every `TestRouter*` test passes, including the four added in Task 1 and the unchanged ones. If the integration test (`kapeproxy/integration_test.go`) breaks because it relied on the old verbatim semantics, update its mock upstream's `ListTools()` to include the names being exercised and re-run. Note this in the commit message.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C <wt> add kapeproxy/internal/proxy/router.go
+git -C <wt> commit -m "feat(kapeproxy/router)!: allowedTools is a glob list intersected with upstream.ListTools (D16)"
+```
+
+The `!` marks the semantic-change scope per the spec (§4); the behaviour is backward-compatible for exact-name allowlists but the contract narrowed.
+
+---
+
+## Task 3: Operator default image version → `latest`
+
+**Files:**
+- Modify: `operator/domain/config/config.go`
+- Create or Modify: `operator/domain/config/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+If `operator/domain/config/config_test.go` does not exist, create it:
+
+```go
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	domainconfig "github.com/kape-io/kape/operator/domain/config"
+)
+
+func TestKapeproxyImageRef_DefaultIsLatest(t *testing.T) {
+	c := domainconfig.KapeConfig{} // nothing set
+	assert.Equal(t, "kape/kapeproxy:latest", c.KapeproxyImageRef(),
+		"D17: in-code default for kapeproxy is :latest, not a release pin")
+}
+
+func TestKapeproxyImageRef_WithDefaults_IsLatest(t *testing.T) {
+	c := domainconfig.KapeConfig{}.WithDefaults()
+	assert.Equal(t, "latest", c.KapeproxyImageVersion,
+		"D17: WithDefaults must set :latest, not :stub or a release pin")
+	assert.Equal(t, "kape/kapeproxy:latest", c.KapeproxyImageRef())
+}
+```
+
+- [ ] **Step 2: Run the test; confirm it fails**
+
+```bash
+cd <wt>/operator && go test ./domain/config/... -v 2>&1 | tail -20
+```
+
+Expected: `TestKapeproxyImageRef_DefaultIsLatest` fails (got `kape/kapeproxy:0.7.0`); `TestKapeproxyImageRef_WithDefaults_IsLatest` fails (got `stub`).
+
+- [ ] **Step 3: Edit `operator/domain/config/config.go`**
+
+Two changes:
+
+- Line 71 (inside `KapeproxyImageRef`): `ver = "0.7.0"` → `ver = "latest"`.
+- Line 100 (inside `WithDefaults`): `c.KapeproxyImageVersion = "stub"` → `c.KapeproxyImageVersion = "latest"`.
+
+- [ ] **Step 4: Run the test; confirm green**
+
+```bash
+cd <wt>/operator && go test ./domain/config/... -v 2>&1 | tail -20
+```
+
+Expected: both new tests pass; nothing else regresses (`go test ./...` from the operator module root should also pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C <wt> add operator/domain/config/config.go operator/domain/config/config_test.go
+git -C <wt> commit -m "fix(operator/config): kapeproxy in-code default is :latest, not a release pin (D17)"
+```
+
+---
+
+## Task 4: Playground + Tilt → `kape/kapeproxy:local`
+
+**Files:**
+- Modify: `playground/docker-compose.playground.yml` (line 44)
+- Modify: `playground/Tiltfile` (lines 21 and 26)
+
+No unit test — the change is to dev tooling and there is no automated harness for either file. Verification is manual.
+
+- [ ] **Step 1: Edit the compose file**
+
+In `playground/docker-compose.playground.yml`, replace the `image:` line under the `kapeproxy:` service:
+
+```diff
+   kapeproxy:
+     build:
+       context: ../kapeproxy
+       dockerfile: ../kapeproxy/Dockerfile
+-    image: kape/kapeproxy:0.7.0
++    image: kape/kapeproxy:local
+     profiles:
+       - build-only
+```
+
+- [ ] **Step 2: Edit the Tiltfile**
+
+In `playground/Tiltfile`, the comment block and the `docker_build` call both reference `0.7.0`:
+
+```diff
+ # ── kapeproxy (Go) ───────────────────────────────────────────────────────────
+-# Builds kape/kapeproxy:0.7.0 locally so the operator can deploy handler pods
++# Builds kape/kapeproxy:local locally so the operator can deploy handler pods
+ # without pulling from a remote registry.  No compose service — the image is
+ # used by the operator-managed Deployment pods inside the k3d cluster.
+ docker_build(
+-    'kape/kapeproxy:0.7.0',
++    'kape/kapeproxy:local',
+     context='../kapeproxy',
+     dockerfile='../kapeproxy/Dockerfile',
+ )
+```
+
+- [ ] **Step 3: Sanity-check no `0.7.0` references remain under `playground/`**
+
+```bash
+git -C <wt> grep -n "kape/kapeproxy:0.7.0" -- playground/
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Manual verification (implementer's local machine)**
+
+```bash
+cd <wt>/playground && podman compose build kapeproxy
+# Then in a separate shell:
+cd <wt>/playground && tilt up
+```
+
+Expected: both commands produce/reference `kape/kapeproxy:local`. Tilt UI shows `docker_build → kape/kapeproxy:local`. Note the manual-verification result in the PR description.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C <wt> add playground/docker-compose.playground.yml playground/Tiltfile
+git -C <wt> commit -m "chore(playground): use kape/kapeproxy:local for dev tooling (D18)"
+```
+
+---
+
+## Task 5: `helm/values.yaml` — add `kapeproxy` block
+
+**Files:**
+- Modify: `helm/values.yaml`
+- Read-only: `helm/templates/operator/*`, `helm/templates/crds/*` (verify whether anything consumes the new values)
+
+- [ ] **Step 1: Inspect current helm templates**
+
+```bash
+git -C <wt> ls-tree -r HEAD -- helm/templates/
+```
+
+Expected at this fixup's time: `.gitkeep` placeholders only — no real templates. If real templates have landed by the time this task runs, read `helm/templates/operator/` and `helm/templates/crds/` to find any reference to `.Values.kapeproxy.image.*`. If found, update those references to match the new block shape (`.repository`, `.tag`, `.pullPolicy`).
+
+- [ ] **Step 2: Add the `kapeproxy` block to `helm/values.yaml`**
+
+Append after the existing `adapters:` block, before `nats:`:
+
+```yaml
+kapeproxy:
+  image:
+    repository: kape/kapeproxy
+    tag: "0.7.0"
+    pullPolicy: IfNotPresent
+```
+
+`0.7.0` is the current release pin (the same value previously hardcoded in Go). Future release bumps edit only this line.
+
+- [ ] **Step 3: Verify chart still renders**
+
+```bash
+cd <wt> && helm template helm/ 2>&1 | tail -20
+```
+
+Expected: chart renders without error. (If `helm` is not installed, fall back to `helm lint helm/` or skip and rely on CI.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C <wt> add helm/values.yaml
+git -C <wt> commit -m "chore(helm): pin kapeproxy image in chart values, not Go code (D17/D18)"
+```
+
+If `helm/templates/` updates were needed, add them to the same commit.
+
+---
+
+## Task 6: Remove the stub CI workflow
+
+**Files:**
+- Delete: `.github/workflows/kapeproxy-stub.yml`
+
+- [ ] **Step 1: Verify no other workflow references the stub**
+
+```bash
+git -C <wt> grep -n "kapeproxy:stub\|kapeproxy-stub" -- .github/
+```
+
+Expected: matches only inside `.github/workflows/kapeproxy-stub.yml` itself (nothing else depends on it).
+
+- [ ] **Step 2: Delete the workflow**
+
+```bash
+git -C <wt> rm .github/workflows/kapeproxy-stub.yml
+```
+
+- [ ] **Step 3: Repo-wide sanity check**
+
+```bash
+git -C <wt> grep -n "kape/kapeproxy:stub\|kapeproxy:stub-" 2>&1 | grep -v "\.git" || echo "clean"
+```
+
+Expected: `clean` (or only matches inside the spec/plan docs created in this fixup which legitimately discuss the removal — those are fine).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C <wt> commit -m "chore(ci): remove transitional kapeproxy-stub workflow (slice-7 Task 12, D19)"
+```
+
+---
+
+## Task 7: Spec/plan housekeeping
+
+**Files:**
+- Modify: `docs/roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md` (line 381 area)
+- Modify: `docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md` (D-series after D15)
+
+- [ ] **Step 1: Annotate the wrong rule in the slice-7 plan**
+
+Open `docs/roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md`. The paragraph starting around line 381:
+
+> "For `List()`, the router reports the names from `allowedTools` when set, and asks the upstream's cached `Available()` tool list otherwise."
+
+Prepend a note (do not delete the historical text — it explains why the PR #57 code looks the way it does):
+
+```markdown
+> **Superseded 2026-05-17 by [`docs/superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md`](../../../../superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md) §3.A / D16.** The rule below is the *original* slice-7 plan; the corrected rule is glob-intersect with `upstream.ListTools()`. Implementation lives under `docs/superpowers/plans/2026-05-17-kapeproxy-slice7-fixup.md`.
+```
+
+- [ ] **Step 2: Extend IMPLEMENTATION-SPEC's decision log**
+
+Open `docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md`. After the D15 row in the Decision Log table (around line 485), add:
+
+```markdown
+| D16 | `allowedTools` is a glob-pattern list (`path.Match`) intersected with `upstream.ListTools()`; both `tools/list` and `tools/call` agree on the same exposed set | Original D14 only defined the `nil` case; the populated case was filled in wrong by the slice-7 plan. See [2026-05-17-kapeproxy-slice7-fixup spec](../../../superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md) §3.A |
+| D17 | Operator in-code default for `kapeproxy` image version is `latest`; release pins live in `helm/values.yaml` | Spec §2.1 already mandates `latest`; release-coupling does not belong in Go. See fixup spec §3.B |
+| D18 | Playground and Tilt build/reference `kape/kapeproxy:local` (unversioned local-dev tag) | Decouple dev tooling from release versions. See fixup spec §3.B |
+| D19 | The slice-5 stub binary and `.github/workflows/kapeproxy-stub.yml` are both removed in the fixup (completes slice-7 Task 12) | Time-bounding the stub per D2 + R1. See fixup spec §3.C |
+```
+
+(If the implementer prefers a single "See fixup spec for D16–D19" row instead of four full rows, that is acceptable — the fixup spec is the canonical source.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C <wt> add \
+  docs/roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md \
+  docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md
+git -C <wt> commit -m "docs(phase6): annotate slice-7 plan supersession; add D16–D19 to decision log"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Run every Go test**
+
+```bash
+cd <wt>/kapeproxy && go test ./... 2>&1 | tail -20
+cd <wt>/operator && go test ./... 2>&1 | tail -20
+```
+
+Expected: both green.
+
+- [ ] **Step 2: Confirm `tools/list` and `tools/call` agree (router-level)**
+
+The router tests added in Task 1 already pin this. Re-run the targeted set once more to be sure:
+
+```bash
+cd <wt>/kapeproxy && go test ./internal/proxy/... -run "TestRouterList_|TestRouterRoute_" -v
+```
+
+Expected: all listed tests pass.
+
+- [ ] **Step 3: Confirm no `kape/kapeproxy:0.7.0` reference outside `helm/values.yaml`**
+
+```bash
+git -C <wt> grep -n "kape/kapeproxy:0.7.0\|\"0.7.0\"" -- :^helm/values.yaml :^docs/
+```
+
+Expected: empty (the only remaining `0.7.0` lives in `helm/values.yaml`; docs may still mention it for context, which is fine).
+
+- [ ] **Step 4: Confirm no `kape/kapeproxy:stub` reference anywhere outside docs**
+
+```bash
+git -C <wt> grep -n "kape/kapeproxy:stub\|kapeproxy:stub-" -- :^docs/
+```
+
+Expected: empty.
+
+- [ ] **Step 5: Confirm `helm template` still renders**
+
+```bash
+cd <wt> && helm template helm/ > /dev/null && echo OK
+```
+
+Expected: `OK`.
+
+---
+
+## Acceptance Checklist
+
+Paste this into the implementation PR's description and tick each item before merge:
+
+- [ ] `cd kapeproxy && go test ./...` — all green, including the new `TestRouterList_GlobIntersectsUpstream`, `TestRouterList_ExactNameNotOnUpstream_Dropped`, `TestRouterRoute_GlobIntersectsUpstream`, `TestRouterRoute_MalformedGlob_DoesNotPanic`, and rewritten `TestRouter_UnavailableUpstream_ExposesNothing`.
+- [ ] `cd operator && go test ./...` — all green, including the new `TestKapeproxyImageRef_DefaultIsLatest` and `TestKapeproxyImageRef_WithDefaults_IsLatest`.
+- [ ] `tools/list` and `tools/call` agree on the same exposed set (covered by router tests above; verified end-to-end if the slice-7 integration test was updated).
+- [ ] `helm template helm/` renders without error and the rendered output references `kape/kapeproxy:0.7.0` (sourced from `values.yaml`).
+- [ ] `git grep "kape/kapeproxy:0.7.0"` returns matches only inside `helm/values.yaml` and `docs/`.
+- [ ] `git grep "kape/kapeproxy:stub\|kapeproxy:stub-"` returns matches only inside `docs/`.
+- [ ] `.github/workflows/kapeproxy-stub.yml` no longer exists.
+- [ ] Playground stack (`podman compose build kapeproxy`) and Tilt (`tilt up`) both build/reference `kape/kapeproxy:local` — manual verification noted in PR description.
+- [ ] `docs/roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md:381` carries the supersession note linking to the fixup spec.
+- [ ] `docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md` decision log includes D16–D19 (or a single forward-reference to the fixup spec).
+- [ ] SBOM ritual from `kape-io/CLAUDE.md` run on `./adapters`, `./operator`, `./task-service`, `./kapeproxy` (this is a code-touching PR — the spec/plan PR does not need it, but the implementation PR does).

--- a/docs/superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md
+++ b/docs/superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md
@@ -4,7 +4,7 @@
 **Author:** Dzung Tran
 **Depends on:** [Phase 6 — Full Operator Design](./2026-04-19-phase6-full-operator-design.md), [`docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md`](../../roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md), [`docs/roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md`](../../roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md)
 **Status:** Proposed
-**Supersedes:** `slice-7-kapeproxy-binary.md:381` (the wrong allowlist-filter rule). Extends IMPLEMENTATION-SPEC D-series with D16–D19.
+**Supersedes:** `slice-7-kapeproxy-binary.md:381` (the wrong allowlist-filter rule) and `docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md:484` (D14 — "expose all" semantics, now D20 deny-by-default). Extends IMPLEMENTATION-SPEC D-series with D16–D20.
 
 ---
 
@@ -40,7 +40,7 @@ So the plan was wrong. The IMPLEMENTATION-SPEC ([D14, line 484](../../roadmap/ph
 
 ## 3. Corrected Behaviours
 
-### 3.A Tools filter — glob intersection with upstream
+### 3.A Tools filter — deny-by-default glob intersection with upstream
 
 **New contract.** `allowedTools` entries are **glob patterns** (shell-style, evaluated with stdlib [`path.Match`](https://pkg.go.dev/path#Match)). The exposed tool set is the *intersection* of upstream's real tool list with the union of glob matches:
 
@@ -48,20 +48,25 @@ So the plan was wrong. The IMPLEMENTATION-SPEC ([D14, line 484](../../roadmap/ph
 exposed[upstream] = { t ∈ upstream.ListTools() | ∃ g ∈ allowedTools : path.Match(g, t) }
 ```
 
-Both `List()` (`tools/list` advertisement) and `Route()` (`tools/call` gating) must compute the same exposed set. A tool that does not appear in `List()` must be rejected by `Route()`, and a tool that does appear in `List()` must be accepted by `Route()` if the upstream actually has it.
+Both `List()` (`tools/list` advertisement) and `Route()` (`tools/call` gating) must compute the same exposed set from this formula. A tool that does not appear in `List()` must be rejected by `Route()`, and a tool that does appear in `List()` must be accepted by `Route()` if the upstream actually has it.
 
-`nil` allowlist preserves the unchanged D14 semantics: expose every tool the upstream advertises.
+**Deny-by-default.** A `nil`, omitted, or `[]` `allowedTools` is an *empty* set of globs. The union of an empty set of globs matches nothing, so the intersection is empty — the upstream contributes **zero** tools. This is a deliberate flip from the original D14 semantics (which treated empty as "expose all"): an audited proxy must require an explicit opt-in before forwarding traffic to an upstream.
+
+To expose every tool an upstream advertises, the operator writes `allowedTools: ["*"]` explicitly. Because upstream tool names are flat (no `/` path separator), the single-glob `"*"` matches every name returned by `upstream.ListTools()`.
 
 **Worked example.** Upstream advertises `["k8s_get_pods", "k8s_list_namespaces", "helm_install"]`:
 
 | `allowedTools` | `List()` output | `Route("up__k8s_get_pods")` | `Route("up__helm_install")` |
 |---|---|---|---|
-| `nil` (omitted) | all three | hits upstream | hits upstream |
+| `nil` / omitted / `[]` | (none) | rejected (deny-by-default) | rejected (deny-by-default) |
 | `["k8s_*"]` | `k8s_get_pods`, `k8s_list_namespaces` | hits upstream | rejected (no glob match) |
+| `["nonexistent"]` | (none) | rejected | rejected |
 | `["k8s_get_pods", "nonexistent"]` | `k8s_get_pods` only | hits upstream | rejected (no glob match) |
 | `["*"]` | all three | hits upstream | hits upstream |
 
 `nonexistent` is silently dropped — it matches no upstream tool, so it cannot be exposed. Exact-name entries (no `*`/`?`/`[`) remain valid because `path.Match("foo", "foo") == true`.
+
+**`tools/call` rejection.** When `Route(namespaced)` returns `(nil, false)` because the deny-by-default rule (or any other check) excluded the tool, the JSON-RPC server responds with MCP error code **`-32601` (method not found)**. This is the same error code already used for genuinely unknown tools — operators cannot distinguish "not in your allowlist" from "doesn't exist upstream" via the wire response, which is the intended security posture (do not leak the upstream's tool catalog to clients without an allowlist entry).
 
 **Files touched.** `kapeproxy/internal/proxy/router.go` (rewrite `List()` and `Route()`); `kapeproxy/internal/proxy/router_test.go` (extend with the worked example).
 
@@ -107,25 +112,26 @@ If the helm chart's deployment templates need to consume this new value (the ope
 
 ## 4. Schema / Contract Changes
 
-The `allowedTools` field on `KapeTool.spec.mcp` changes its **interpretation** from "list of exact tool names" (implicit, never stated) to "list of glob patterns evaluated with stdlib `path.Match`". This is a semantic change, not a schema change:
+The `allowedTools` field on `KapeTool.spec.mcp` changes its **interpretation** from "list of exact tool names with empty = expose all" (implicit, never stated; partially encoded in D14) to "list of glob patterns evaluated with stdlib `path.Match`, where missing/empty means **deny all** and `[\"*\"]` means allow all". The YAML shape is unchanged; the *meaning* of omitting the field is now opposite to D14:
 
 - The CRD field stays `[]string`.
 - The `kapeproxy-config` ConfigMap YAML format does not change.
 - Exact-name allowlists remain valid because a name with no glob metacharacters (`*`, `?`, `[`) matches only itself under `path.Match`.
+- **Omitting `allowedTools` now means "expose nothing from this upstream"** rather than "expose everything". Operators relying on the previous "omit = expose all" behaviour (from D14 or from the kapetool sidecar precedent) must migrate by writing `allowedTools: ["*"]` explicitly — or, preferably, an explicit minimum-privilege allowlist such as `["k8s_*"]`.
 
-No CRD version bump, no admission webhook update, no operator-side migration. The only behaviour change visible to a user with an existing `allowedTools: ["foo_bar"]` is: previously the kapeproxy would emit `up__foo_bar` even if the upstream didn't have `foo_bar`; now `up__foo_bar` is only emitted (and only callable) if the upstream actually advertises `foo_bar`.
+No CRD version bump, no admission webhook update, no operator-side render change (the operator may continue to omit the field for KapeTools with no `allowedTools` — kapeproxy will now interpret that omission as deny-all, which is the new safe default). The behaviour change visible to a user with an existing `allowedTools: ["foo_bar"]` is: previously the kapeproxy would emit `up__foo_bar` even if the upstream didn't have `foo_bar`; now `up__foo_bar` is only emitted (and only callable) if the upstream actually advertises `foo_bar`. The behaviour change visible to a user with **no** `allowedTools` field is much larger: the upstream now contributes zero tools instead of all of them.
 
 ---
 
 ## 5. Design Decisions
 
-Extends the IMPLEMENTATION-SPEC D-series (last entry: D15). These four decisions are added in this fixup spec; the IMPLEMENTATION-SPEC is updated to reference this document as the source of truth.
+Extends the IMPLEMENTATION-SPEC D-series (last entry: D15). These decisions are added in this fixup spec; the IMPLEMENTATION-SPEC is updated to reference this document as the source of truth. D20 explicitly **supersedes D14**.
 
-### D16 — `allowedTools` is a glob-pattern list intersected with the upstream tool list
+### D16 — `allowedTools` is a deny-by-default glob list intersected with the upstream tool list
 
-`allowedTools` entries are shell-style glob patterns evaluated with stdlib `path.Match`. Both `tools/list` and `tools/call` compute the exposed set as the intersection of upstream-advertised tools with the union of glob matches. `nil` preserves D14 semantics ("expose all"). Malformed globs are logged at startup and treated as matching nothing; one bad pattern cannot take the proxy offline.
+`allowedTools` entries are shell-style glob patterns evaluated with stdlib `path.Match`. Both `tools/list` and `tools/call` compute the exposed set as the intersection of upstream-advertised tools with the union of glob matches. A `nil`, omitted, or empty `allowedTools` is an empty set of globs and so exposes **nothing** (deny-by-default; see D20). `["*"]` is the explicit opt-in to expose every upstream tool. Both paths enforce the same rule: `tools/list` simply omits non-matching tools; `tools/call` rejects them with MCP error `-32601` (method not found). Malformed globs are logged at startup and treated as matching nothing; one bad pattern cannot take the proxy offline.
 
-**Rationale.** The original "list of exact names emitted verbatim" rule produced two real bugs: `tools/list` could advertise tools the upstream cannot serve, and `tools/call` could accept calls to tools that do not exist upstream. Glob-intersection makes the two paths agree and lets operators write `["k8s_*"]` instead of enumerating every tool by hand.
+**Rationale.** The original "list of exact names emitted verbatim" rule produced two real bugs: `tools/list` could advertise tools the upstream cannot serve, and `tools/call` could accept calls to tools that do not exist upstream. Glob-intersection makes the two paths agree and lets operators write `["k8s_*"]` instead of enumerating every tool by hand. Deny-by-default (D20) closes the implicit "expose all" hole left by D14.
 
 ### D17 — Operator in-code default for `kapeproxy` image version is `latest`
 
@@ -145,6 +151,18 @@ Extends the IMPLEMENTATION-SPEC D-series (last entry: D15). These four decisions
 
 **Rationale.** D2 + R1 in the original IMPLEMENTATION-SPEC explicitly time-bounded the stub to "removed in slice 7". A CI workflow that still publishes a `kape/kapeproxy:stub` tag — even on `workflow_dispatch` — keeps that artifact alive and creates a path for it to drift back into use.
 
+### D20 — `allowedTools` is deny-by-default; supersedes D14
+
+**Supersedes** [`docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md` D14, line 484](../../roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md). D14 stated that `allowedTools: []` (or omitted) means "expose all" — matching the legacy kapetool sidecar precedent. D20 flips this: a `nil`, omitted, or `[]` `allowedTools` exposes **zero** tools from the upstream. The operator opts into "expose all" explicitly by writing `allowedTools: ["*"]` (the single glob `*` matches every flat tool name returned by `upstream.ListTools()`).
+
+The rule applies uniformly to both `tools/list` (the upstream contributes no namespaced names) and `tools/call` (rejected with MCP error `-32601` because `Route()` returns `(nil, false)`).
+
+**Rationale.** Security posture for an audited proxy: an operator must opt in to forwarding traffic to an upstream, not opt out. "Expose all by default" makes it trivially easy to misconfigure a handler — adding a new upstream with no `allowedTools` would have silently exposed every tool the upstream advertises. The previous behaviour also leaked information about the upstream's tool catalog to any client that called `tools/list` without the operator having ever sanctioned that exposure. Deny-by-default forces the question to be answered at configuration time.
+
+**Migration.** Existing `KapeTool` resources whose `spec.mcp.allowedTools` is omitted or `[]` will, after this fixup ships, contribute **no** tools through kapeproxy. To retain the old D14 "expose all" behaviour, operators must add `allowedTools: ["*"]` explicitly. Preferred migration is to write a minimum-privilege allowlist (e.g. `["k8s_*"]`) — `["*"]` is supported but discouraged.
+
+**Operator-side impact.** The operator's `renderKapeproxyConfig` does **not** change behaviour. It may continue to omit `allowedTools` from the rendered `kapeproxy-config` ConfigMap when the KapeTool's `spec.mcp.allowedTools` is empty — the on-the-wire YAML shape is unchanged, and kapeproxy now interprets that omission as deny-all (the new safe default). The semantic flip lives entirely in kapeproxy's router.
+
 ---
 
 ## 6. Out of Scope
@@ -162,11 +180,27 @@ This fixup is intentionally narrow. The following are **not** touched:
 
 ## 7. Migration and Backward Compatibility
 
-### `allowedTools` semantic change
+### `allowedTools` semantic change — BREAKING
 
-Existing `KapeTool.spec.mcp.allowedTools` values written as exact tool names (e.g. `["query_dashboards", "get_alert"]`) continue to work unchanged because `path.Match("query_dashboards", "query_dashboards") == true`. No CRD migration is required.
+> **Breaking change.** This fixup flips `allowedTools` from "omit means expose all" (D14) to "omit means expose nothing" (D20). Any `KapeTool` whose `spec.mcp.allowedTools` is omitted or `[]` will, after the fixup ships, contribute **zero** tools through kapeproxy. Operators must touch every such KapeTool to either (a) write an explicit minimum-privilege allowlist (preferred) or (b) add `allowedTools: ["*"]` (legacy "expose all", discouraged). There is no soft-rollover or grace period — the behaviour change is immediate at upgrade.
 
-The only observable behaviour change for an existing deployment is: a stale allowlist entry that names a tool the upstream no longer advertises will silently drop out of `tools/list` and `tools/call` will reject it (instead of accepting the call and letting the upstream return an unknown-tool error). This is the desired behaviour — it surfaces stale config locally instead of routing dead calls.
+Existing `KapeTool.spec.mcp.allowedTools` values written as *populated* exact-name lists (e.g. `["query_dashboards", "get_alert"]`) continue to work unchanged because `path.Match("query_dashboards", "query_dashboards") == true`. The breaking case is specifically the empty/omitted form.
+
+Migration steps for operators:
+
+1. **Inventory.** `kubectl get kapetool -A -o jsonpath='{range .items[?(!@.spec.mcp.allowedTools)]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}'` (or equivalent) lists every KapeTool that will lose all exposed tools post-upgrade.
+2. **Decide per tool.** For each, pick:
+   - **Preferred:** write an explicit allowlist matching only the tools that handler needs (e.g. `["k8s_get_*", "helm_list"]`). Minimum-privilege is the point of D20.
+   - **Legacy escape hatch:** write `allowedTools: ["*"]` to retain pre-D20 "expose all" semantics. Discouraged because it re-introduces the security hole D20 closed.
+3. **Apply before the kapeproxy upgrade rolls.** Operators can edit KapeTools at any time — the operator's `renderKapeproxyConfig` faithfully translates the new field value into `kapeproxy-config` regardless of which kapeproxy version is running. The change only "matters" once the new kapeproxy binary is in the handler pod.
+
+Additionally, the same in-allowlist behaviour change from the original spec still applies: a stale allowlist entry that names a tool the upstream no longer advertises will silently drop out of `tools/list` and `tools/call` will reject it (instead of accepting the call and letting the upstream return an unknown-tool error). This surfaces stale config locally instead of routing dead calls.
+
+### Operator-side render path is unchanged
+
+The operator's `renderKapeproxyConfig` does **not** need behaviour changes for D20. The existing "omit `allowedTools` from the rendered YAML when the slice is empty" optimisation remains correct on the wire — kapeproxy now interprets that omission as deny-all, which is the safe default under D20. Existing operator `kapeproxy-config` golden tests stay green; no golden file updates are required.
+
+The operator's envtest scenarios *should* gain a small assertion (see plan Task 5b) that a KapeTool with a populated `allowedTools` glob exposes exactly the intersection through kapeproxy. This is light-touch coverage of the contract from the operator's vantage point and is flagged as optional-but-recommended in the plan.
 
 ### Operator in-code default change (`0.7.0` → `latest`)
 
@@ -188,13 +222,14 @@ No production impact — playground tags never reached a registry. Local dev use
 ### Files / lines superseded
 
 - [`docs/roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md:381`](../../roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md) — the wrong rule ("`List()` reports the names from `allowedTools` when set"). This line gets a note pointing at the present spec.
+- Supersedes D14 in [`docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md:484`](../../roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md) (now D20 in this fixup) — `allowedTools` flips from "expose all when empty" to deny-by-default.
 - `kapeproxy/internal/proxy/router.go:50-55,81-84` (PR #57 branch) — current implementation of `Route()` and `List()` that implements the wrong rule.
 - `operator/domain/config/config.go:71,100` (PR #57 branch) — wrong defaults (`0.7.0` and `stub`).
 - `playground/docker-compose.playground.yml:44`, `playground/Tiltfile:21,26` (PR #57 branch) — `kape/kapeproxy:0.7.0` references.
 
 ### Files / lines extended
 
-- [`docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md`](../../roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md) — D-series gets D16–D19 (or a single reference to this spec as the source of truth for those decisions).
+- [`docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md`](../../roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md) — D-series gets D16–D20 (or a single reference to this spec as the source of truth for those decisions). D20 explicitly supersedes D14.
 
 ### Original slice-7 tasks closed by this fixup
 

--- a/docs/superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md
+++ b/docs/superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md
@@ -1,0 +1,208 @@
+# kapeproxy Slice 7 Fixup — Spec
+
+**Date:** 2026-05-17
+**Author:** Dzung Tran
+**Depends on:** [Phase 6 — Full Operator Design](./2026-04-19-phase6-full-operator-design.md), [`docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md`](../../roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md), [`docs/roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md`](../../roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md)
+**Status:** Proposed
+**Supersedes:** `slice-7-kapeproxy-binary.md:381` (the wrong allowlist-filter rule). Extends IMPLEMENTATION-SPEC D-series with D16–D19.
+
+---
+
+## 1. Goal
+
+Correct three divergences that slipped through slice 7 ([PR #57](https://github.com/dzungtr/kape/pull/57)) before it merges:
+
+1. **Tools-filter semantics** — `allowedTools` was implemented as a literal list of exact names that get emitted verbatim. The corrected rule is *glob patterns evaluated against the upstream's real tool list* — `tools/list` and `tools/call` must agree on the same exposed set.
+2. **Image-tag defaults** — operator and dev tooling hardcoded the release pin `0.7.0`. The corrected defaults are `latest` (operator code), `:local` (playground / Tilt), and a single release pin lives in `helm/values.yaml`.
+3. **Two undone slice-7 tasks** — Task 12 (remove the stub CI workflow) and Task 14 (add the `kapeproxy` block to `helm/values.yaml`) were silently dropped. Both are picked up here.
+
+No runtime behaviour beyond these three items changes. JSON-RPC server, redaction, audit logging, OTEL, upstream client, and the operator reconcilers are untouched.
+
+---
+
+## 2. Background
+
+PR #57 (`feat/phase6-slice7-kapeproxy-binary`) shipped the production `kapeproxy` binary per the slice-7 plan. Author review surfaced two classes of divergence from the project's vision plus two carried-over tasks. Each has a different root cause:
+
+### How each divergence happened
+
+**A. Tools filter (plan-level error).** The slice-7 plan ([`slice-7-kapeproxy-binary.md:381`](../../roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md)) literally instructed:
+
+> "For `List()`, the router reports the names from `allowedTools` when set, and asks the upstream's cached `Available()` tool list otherwise."
+
+So the plan was wrong. The IMPLEMENTATION-SPEC ([D14, line 484](../../roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md)) only defined the `nil` case (`"expose all"`). The populated case was under-specified, the plan filled it with the wrong rule, and the implementer faithfully followed the plan. The shipped `kapeproxy/internal/proxy/router.go:81-84` emits allowlist entries verbatim and `router.go:50-55` gates `tools/call` by membership in the allowlist without consulting the upstream — so `tools/list` can advertise tools that don't exist, and `tools/call` can accept calls to tools the upstream cannot serve.
+
+**B. Image tags (mechanical port-forward error).** The slice-5 plan codified `ver = "stub"` as a *transitional* default. Slice 7 was meant to replace it. The implementer instead hardcoded `0.7.0` in operator code (`operator/domain/config/config.go:71`) and in playground/Tilt files. The IMPLEMENTATION-SPEC ([§2.1, line 161](../../roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md)) actually mandates `latest` as the default. The default got mechanically swapped from one wrong value (`stub`) to another wrong value (`0.7.0`) without reading the spec.
+
+**C. Two undone tasks (scope-drop).** Task 12 (remove the slice-5 stub CI workflow at `.github/workflows/kapeproxy-stub.yml`) and Task 14 (add the `kapeproxy` block to `helm/values.yaml`) both appear in the original slice-7 plan but were skipped during implementation. The stub workflow is still in the tree (now only triggerable via `workflow_dispatch`) and `helm/values.yaml` has no `kapeproxy:` block at all.
+
+---
+
+## 3. Corrected Behaviours
+
+### 3.A Tools filter — glob intersection with upstream
+
+**New contract.** `allowedTools` entries are **glob patterns** (shell-style, evaluated with stdlib [`path.Match`](https://pkg.go.dev/path#Match)). The exposed tool set is the *intersection* of upstream's real tool list with the union of glob matches:
+
+```
+exposed[upstream] = { t ∈ upstream.ListTools() | ∃ g ∈ allowedTools : path.Match(g, t) }
+```
+
+Both `List()` (`tools/list` advertisement) and `Route()` (`tools/call` gating) must compute the same exposed set. A tool that does not appear in `List()` must be rejected by `Route()`, and a tool that does appear in `List()` must be accepted by `Route()` if the upstream actually has it.
+
+`nil` allowlist preserves the unchanged D14 semantics: expose every tool the upstream advertises.
+
+**Worked example.** Upstream advertises `["k8s_get_pods", "k8s_list_namespaces", "helm_install"]`:
+
+| `allowedTools` | `List()` output | `Route("up__k8s_get_pods")` | `Route("up__helm_install")` |
+|---|---|---|---|
+| `nil` (omitted) | all three | hits upstream | hits upstream |
+| `["k8s_*"]` | `k8s_get_pods`, `k8s_list_namespaces` | hits upstream | rejected (no glob match) |
+| `["k8s_get_pods", "nonexistent"]` | `k8s_get_pods` only | hits upstream | rejected (no glob match) |
+| `["*"]` | all three | hits upstream | hits upstream |
+
+`nonexistent` is silently dropped — it matches no upstream tool, so it cannot be exposed. Exact-name entries (no `*`/`?`/`[`) remain valid because `path.Match("foo", "foo") == true`.
+
+**Files touched.** `kapeproxy/internal/proxy/router.go` (rewrite `List()` and `Route()`); `kapeproxy/internal/proxy/router_test.go` (extend with the worked example).
+
+**Error handling.** Stdlib `path.Match` returns `ErrBadPattern` when a glob is malformed. The router treats malformed globs as "matches nothing" (logged once per pattern at startup so operators see the misconfiguration early). It does not panic and does not refuse to start — one misconfigured glob must not take the whole proxy offline.
+
+### 3.B Image-tag defaults — `latest` / `:local` / chart pin
+
+| Surface | Old (PR #57) | New |
+|---|---|---|
+| Operator default (`config.go:71`) | `"0.7.0"` | `"latest"` |
+| Operator default (`config.go:100`, `WithDefaults`) | `"stub"` | `"latest"` |
+| Playground compose | `kape/kapeproxy:0.7.0` | `kape/kapeproxy:local` |
+| Tiltfile | `kape/kapeproxy:0.7.0` | `kape/kapeproxy:local` |
+| Helm chart values | (missing) | `kapeproxy.image.tag: "0.7.0"` (or current release) |
+
+**Rationale.** Three different consumers want three different things from a default:
+
+- **Operator code** runs in production-like contexts. Its in-code default should be the moving tag the project always publishes (`latest`), so the operator works on a fresh cluster without chart values.
+- **Playground / Tilt** are local-dev contexts. They build the image locally and never pull from a registry. The `:local` tag is the unversioned local-dev convention and is decoupled from any release.
+- **Helm chart** is the declarative deployment surface where a release pin belongs. Anyone deploying to a real cluster overrides via chart values; the chart's `values.yaml` carries the current release pin (`0.7.0` at fixup time).
+
+Release pins do not belong in Go code or in dev tooling. The current shipped PR violates this rule in three places.
+
+**Files touched.** `operator/domain/config/config.go` (two lines); `playground/docker-compose.playground.yml:44`; `playground/Tiltfile:21,26`; `helm/values.yaml` (new block).
+
+### 3.C Two undone tasks
+
+**Task 12 — remove the stub CI workflow.** `.github/workflows/kapeproxy-stub.yml` still exists on the PR #57 branch. It is currently `workflow_dispatch`-only (so it does not run on every main merge, but it is still a maintained artifact that publishes `kapeproxy:stub` images on demand). The slice-5 stub binary is being removed by slice-7's Task 12; its CI workflow must go with it.
+
+**Task 14 — add the `kapeproxy` block to `helm/values.yaml`.** The chart's `values.yaml` enumerates `operator`, `taskService`, `runtime`, `dashboard`, and `adapters` image references. There is no `kapeproxy:` block. After this fixup, the chart owns the release pin:
+
+```yaml
+kapeproxy:
+  image:
+    repository: kape/kapeproxy
+    tag: "0.7.0"
+    pullPolicy: IfNotPresent
+```
+
+If the helm chart's deployment templates need to consume this new value (the operator passes the image ref through `kape-config`, so chart values typically flow into a ConfigMap rather than a Deployment env var directly), the implementer must wire that — see the plan's Task 5 for the read-and-verify step. Today the `helm/templates/operator/` directory is a placeholder (`.gitkeep` only), so no template edits are required by this fixup; the values block is the canonical declaration regardless.
+
+---
+
+## 4. Schema / Contract Changes
+
+The `allowedTools` field on `KapeTool.spec.mcp` changes its **interpretation** from "list of exact tool names" (implicit, never stated) to "list of glob patterns evaluated with stdlib `path.Match`". This is a semantic change, not a schema change:
+
+- The CRD field stays `[]string`.
+- The `kapeproxy-config` ConfigMap YAML format does not change.
+- Exact-name allowlists remain valid because a name with no glob metacharacters (`*`, `?`, `[`) matches only itself under `path.Match`.
+
+No CRD version bump, no admission webhook update, no operator-side migration. The only behaviour change visible to a user with an existing `allowedTools: ["foo_bar"]` is: previously the kapeproxy would emit `up__foo_bar` even if the upstream didn't have `foo_bar`; now `up__foo_bar` is only emitted (and only callable) if the upstream actually advertises `foo_bar`.
+
+---
+
+## 5. Design Decisions
+
+Extends the IMPLEMENTATION-SPEC D-series (last entry: D15). These four decisions are added in this fixup spec; the IMPLEMENTATION-SPEC is updated to reference this document as the source of truth.
+
+### D16 — `allowedTools` is a glob-pattern list intersected with the upstream tool list
+
+`allowedTools` entries are shell-style glob patterns evaluated with stdlib `path.Match`. Both `tools/list` and `tools/call` compute the exposed set as the intersection of upstream-advertised tools with the union of glob matches. `nil` preserves D14 semantics ("expose all"). Malformed globs are logged at startup and treated as matching nothing; one bad pattern cannot take the proxy offline.
+
+**Rationale.** The original "list of exact names emitted verbatim" rule produced two real bugs: `tools/list` could advertise tools the upstream cannot serve, and `tools/call` could accept calls to tools that do not exist upstream. Glob-intersection makes the two paths agree and lets operators write `["k8s_*"]` instead of enumerating every tool by hand.
+
+### D17 — Operator in-code default for `kapeproxy` image version is `latest`
+
+`KapeproxyImageVersion` defaults to `"latest"` in `operator/domain/config/config.go` (both the inline default in `KapeproxyImageRef()` and the `WithDefaults()` assignment). Release pins live in `helm/values.yaml`, not in Go code.
+
+**Rationale.** The IMPLEMENTATION-SPEC §2.1 already mandates `latest` as the operator's default; the PR-time release pin is a deployment-surface concern. Hardcoding `0.7.0` in Go code creates a release-coupling that has to be unwound every time the kapeproxy image bumps.
+
+### D18 — Playground and Tilt reference `kape/kapeproxy:local`
+
+`playground/docker-compose.playground.yml` and `playground/Tiltfile` build and reference `kape/kapeproxy:local`. The `:local` tag is the unversioned local-dev convention; it never appears in a registry and is decoupled from any release version.
+
+**Rationale.** Local dev should not pretend to be a release. The previous `:0.7.0` tag in playground files looked like a pull from a registry but was actually a local build — confusing, and it meant every release bump had to touch dev tooling.
+
+### D19 — The slice-5 stub binary and its CI pipeline are removed in this fixup
+
+`.github/workflows/kapeproxy-stub.yml` is deleted as part of this fixup, completing slice-7's Task 12 (the binary itself was already removed by PR #57; the workflow was missed). No future PR should push `kape/kapeproxy:stub` to any registry.
+
+**Rationale.** D2 + R1 in the original IMPLEMENTATION-SPEC explicitly time-bounded the stub to "removed in slice 7". A CI workflow that still publishes a `kape/kapeproxy:stub` tag — even on `workflow_dispatch` — keeps that artifact alive and creates a path for it to drift back into use.
+
+---
+
+## 6. Out of Scope
+
+This fixup is intentionally narrow. The following are **not** touched:
+
+- **kapeproxy runtime internals** — JSON-RPC server (`server.go`), upstream client (`upstream.go`), redaction (`redaction.go`), audit logging (`audit.go`), OTEL bootstrap (`otel.go`), config parser (`config.go`).
+- **MCP SDK** — no upgrade, no API surface changes.
+- **Operator reconcilers** — `KapeHandlerReconciler`, `KapeToolReconciler`, `KapeSchemaReconciler` are all unaffected. The `kapeproxy-config` ConfigMap render path is unaffected because the YAML shape is unchanged (D16 only changes how the proxy *interprets* `allowedTools`, not how the operator *writes* it).
+- **CRD schemas** — no CRD version bump; no validation webhook update.
+- **kapeproxy module dependencies** — no new imports beyond stdlib `path`. (The router already exists; this is a rewrite of two methods, not a new package.)
+- **End-to-end envtest** — the existing slice-7 e2e test continues to assert the same observable outcomes. If the test happened to assert "allowedTools entries appear verbatim in `tools/list`", it gets updated as part of Task 1's red-green loop.
+
+---
+
+## 7. Migration and Backward Compatibility
+
+### `allowedTools` semantic change
+
+Existing `KapeTool.spec.mcp.allowedTools` values written as exact tool names (e.g. `["query_dashboards", "get_alert"]`) continue to work unchanged because `path.Match("query_dashboards", "query_dashboards") == true`. No CRD migration is required.
+
+The only observable behaviour change for an existing deployment is: a stale allowlist entry that names a tool the upstream no longer advertises will silently drop out of `tools/list` and `tools/call` will reject it (instead of accepting the call and letting the upstream return an unknown-tool error). This is the desired behaviour — it surfaces stale config locally instead of routing dead calls.
+
+### Operator in-code default change (`0.7.0` → `latest`)
+
+Operators running the operator binary with no `kape-config` override for `kapeproxy.version` will get `kape/kapeproxy:latest` after upgrading, where previously they got `kape/kapeproxy:0.7.0`. If pinning to a specific kapeproxy release is required, the operator must either:
+
+1. Set `kapeproxy.version: 0.7.0` in the `kape-config` ConfigMap (existing override path), or
+2. Deploy via the Helm chart and let chart values flow through (chart's `values.yaml` carries the pin per D17).
+
+This is a one-line operator-facing change. Call it out in the implementation PR's description so an upgrader notices.
+
+### Playground `:0.7.0` → `:local`
+
+No production impact — playground tags never reached a registry. Local dev users will need a fresh `tilt up` / `podman compose build` to pick up the renamed local image; the old `kape/kapeproxy:0.7.0` local image may still be on their machine and can be removed with `podman rmi kape/kapeproxy:0.7.0`.
+
+---
+
+## 8. References
+
+### Files / lines superseded
+
+- [`docs/roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md:381`](../../roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md) — the wrong rule ("`List()` reports the names from `allowedTools` when set"). This line gets a note pointing at the present spec.
+- `kapeproxy/internal/proxy/router.go:50-55,81-84` (PR #57 branch) — current implementation of `Route()` and `List()` that implements the wrong rule.
+- `operator/domain/config/config.go:71,100` (PR #57 branch) — wrong defaults (`0.7.0` and `stub`).
+- `playground/docker-compose.playground.yml:44`, `playground/Tiltfile:21,26` (PR #57 branch) — `kape/kapeproxy:0.7.0` references.
+
+### Files / lines extended
+
+- [`docs/roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md`](../../roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md) — D-series gets D16–D19 (or a single reference to this spec as the source of truth for those decisions).
+
+### Original slice-7 tasks closed by this fixup
+
+- Task 12 (line ~2307): remove `.github/workflows/kapeproxy-stub.yml` (the stub binary was removed; the workflow was not).
+- Task 14 (line ~2440): add the `kapeproxy` block to `helm/values.yaml`.
+
+### Related
+
+- [PR #57 — slice 7 production kapeproxy binary](https://github.com/dzungtr/kape/pull/57)
+- [Original slice-7 plan](../../roadmap/phases/06-full-operator/plans/slice-7-kapeproxy-binary.md)
+- [Phase 6 IMPLEMENTATION-SPEC](../../roadmap/phases/06-full-operator/IMPLEMENTATION-SPEC.md)


### PR DESCRIPTION
## Summary

- New spec + plan capturing the corrected vision for [PR #57](https://github.com/dzungtr/kape/pull/57) (slice 7).
- **Tools filter:** `allowedTools` entries are glob patterns intersected with `upstream.ListTools()` — current PR #57 emits the allowlist verbatim, which advertises non-existent tools and gates calls without consulting the upstream.
- **Image-tag defaults:** operator default -> `latest`; playground/Tilt -> `:local`; release pins move to `helm/values.yaml`.
- Closes slice-7 Tasks 12 (remove stub CI workflow) and 14 (add helm kapeproxy block) that were dropped during slice-7 implementation.

## Why a separate PR

Per project convention (root `CLAUDE.md`): spec and plan changes ship as PRs before implementation, not inline with the code change. Implementation against PR #57's branch (or a follow-up branch from main once PR #57 merges) follows once this lands.

## Files

- `docs/superpowers/specs/2026-05-17-kapeproxy-slice7-fixup.md`
- `docs/superpowers/plans/2026-05-17-kapeproxy-slice7-fixup.md`

## Decisions added to the Phase 6 D-series

- **D16** — `allowedTools` is a glob-pattern list (`path.Match`) intersected with `upstream.ListTools()`; `tools/list` and `tools/call` agree on the same exposed set.
- **D17** — Operator in-code default for kapeproxy image is `latest`; release pins live in `helm/values.yaml`.
- **D18** — Playground and Tilt build/reference `kape/kapeproxy:local` (unversioned local-dev tag).
- **D19** — The slice-5 stub binary and `.github/workflows/kapeproxy-stub.yml` are both removed in the fixup (completes slice-7 Task 12).

## Test plan

- [ ] Reviewer reads both files end-to-end and confirms the corrected semantics match intent
- [ ] D16-D19 are unambiguous enough that a future implementer cannot repeat the slice-7 mistake

> Note: stub workflow on the PR #57 branch is currently `workflow_dispatch`-only (not push-on-main as previously thought). The spec calls this out explicitly; D19 still applies — a `workflow_dispatch` workflow that publishes `kapeproxy:stub` keeps that artifact alive.

Generated with [Claude Code](https://claude.com/claude-code)