### PR TITLE
fix(runtime): wire load_skill into graph tool registry (P7/03)

### DIFF
--- a/runtime/src/kape_runtime/graph/graph.py
+++ b/runtime/src/kape_runtime/graph/graph.py
@@ -19,6 +19,7 @@ from kape_runtime.graph.nodes import (
 from kape_runtime.graph.state import AgentState
 from kape_runtime.memory import build_memory_tool
 from kape_runtime.schema_loader import make_structured_llm
+from kape_runtime.skills import make_load_skill_tool
 
 
 def build_graph(
@@ -44,7 +45,12 @@ def build_graph(
     tools: list[BaseTool] = list(mcp_tools)
     if (memory_tool := build_memory_tool()) is not None:
         tools.append(memory_tool)
-    # TODO(Phase 7.3): when kape_runtime.skills lands, append make_load_skill_tool(...)
+    render_ctx = {
+        "handler_name": kape_cfg.handler_name,
+        "cluster_name": kape_cfg.cluster_name,
+        "namespace": kape_cfg.handler_namespace,
+    }
+    tools.append(make_load_skill_tool(jinja_env, render_ctx))
 
     graph = StateGraph(AgentState)
 

--- a/runtime/tests/test_graph.py
+++ b/runtime/tests/test_graph.py
@@ -366,7 +366,33 @@ async def test_build_graph_omits_memory_tool_when_qdrant_env_unset(monkeypatch):
     bound_tools = base_llm.bind_tools.call_args.args[0]
     tool_names = [t.name for t in bound_tools]
     assert "search_memory" not in tool_names
-    assert tool_names == ["fake_mcp_tool"]
+    assert "fake_mcp_tool" in tool_names
+    assert "load_skill" in tool_names
+
+
+@pytest.mark.asyncio
+async def test_build_graph_always_registers_load_skill_tool(monkeypatch):
+    """load_skill must be registered unconditionally regardless of env vars."""
+    monkeypatch.delenv("QDRANT_URL", raising=False)
+    monkeypatch.delenv("QDRANT_COLLECTION", raising=False)
+
+    kape_cfg = make_kape_config()
+    llm_cfg = make_llm_config()
+    schema_cfg = SchemaConfig(
+        name="test",
+        json_schema={"type": "object", "properties": {"decision": {"type": "string"}}},
+    )
+
+    base_llm, _ = _build_base_llm([AIMessage(content="ok")])
+    base_llm.with_structured_output = MagicMock(
+        return_value=MagicMock(ainvoke=AsyncMock(return_value={"decision": "ignore"}))
+    )
+
+    build_graph(base_llm, kape_cfg, llm_cfg, schema_cfg, mcp_tools=[])
+
+    bound_tools = base_llm.bind_tools.call_args.args[0]
+    tool_names = [t.name for t in bound_tools]
+    assert "load_skill" in tool_names
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `skills.py` shipped `make_load_skill_tool` but `graph/graph.py` had only a `# TODO(Phase 7.3)` placeholder, so `load_skill` was never registered in the ReAct graph tool set
- Calls `make_load_skill_tool(jinja_env, render_ctx)` unconditionally in `build_graph`, using the same `kape_cfg` fields as the system-prompt render context (`handler_name`, `cluster_name`, `namespace`)
- Updates the existing no-memory-tool test to account for `load_skill` now appearing in the bound tools list; adds a dedicated test asserting unconditional registration

## Test plan

- [ ] `conda run -n kape-runtime pytest runtime/tests/test_skills.py runtime/tests/test_graph.py -v` — 20 tests, all passing
- [ ] Snyk code scan: 11 findings, all pre-existing (none in `graph/graph.py`)

Closes #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)