### PR TITLE
fix(runtime): wire ActionsRouter into consumer (P7/05)

### DIFF
--- a/runtime/src/kape_runtime/config.py
+++ b/runtime/src/kape_runtime/config.py
@@ -17,6 +17,11 @@ class KapeConfig:
     max_iterations: int
     schema_name: str
     max_event_age_seconds: int
+    actions: list[dict[str, Any]] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.actions is None:
+            self.actions = []
 
 
 @dataclass
@@ -92,6 +97,10 @@ def load_config(settings_file: str | None = None) -> Config:
         env_switcher="KAPE_ENV",
     )
 
+    raw_actions = _dynabox_to_dict(raw.get("kape", {}).get("actions", []))
+    if not isinstance(raw_actions, list):
+        raw_actions = []
+
     return Config(
         kape=KapeConfig(
             handler_name=raw.kape.handler_name,
@@ -101,6 +110,7 @@ def load_config(settings_file: str | None = None) -> Config:
             max_iterations=raw.kape.max_iterations,
             schema_name=raw.kape.schema_name,
             max_event_age_seconds=raw.kape.max_event_age_seconds,
+            actions=raw_actions,
         ),
         llm=LLMConfig(
             provider=raw.llm.provider,

--- a/runtime/src/kape_runtime/consumer.py
+++ b/runtime/src/kape_runtime/consumer.py
@@ -12,6 +12,7 @@ import nats
 import tenacity
 from ulid import ULID
 
+from kape_runtime.actions.router import run_actions
 from kape_runtime.config import KapeConfig, NatsConfig
 from kape_runtime.dlq import publish_dlq
 from kape_runtime.metrics import (
@@ -54,10 +55,12 @@ class ConsumerLoop:
         task_svc: TaskServiceClient,
         graph: Any,
         kape_cfg: KapeConfig,
+        qdrant_client: Any = None,
     ) -> None:
         self._task_svc = task_svc
         self._graph = graph
         self._kape_cfg = kape_cfg
+        self._qdrant_client = qdrant_client
         self._nc: Any = None  # set in run() so process_message() can publish to DLQ
 
     async def process_message(self, msg: Any) -> None:
@@ -162,6 +165,35 @@ class ConsumerLoop:
                 }
 
             await self._task_svc.update_status(task["id"], **update_kwargs)
+
+            # 6. Run post-decision actions (event-publish, webhook, save_memory)
+            #    Only when schema_output is present and actions are configured.
+            if schema_output is not None and kape_cfg.actions:
+                parent_task_id: str = event.extensions.get("parent_task_id", "")
+                action_results = await run_actions(
+                    schema_output=schema_output,
+                    actions=kape_cfg.actions,
+                    nats_client=self._nc,
+                    qdrant_client=self._qdrant_client,
+                    handler_name=kape_cfg.handler_name,
+                    task_id=task["id"],
+                    parent_task_id=parent_task_id,
+                )
+                for result in action_results:
+                    log_fn = logger.warning if result["status"] == "error" else logger.info
+                    log_fn(
+                        "Action %r (%s): %s%s",
+                        result["name"],
+                        result["type"],
+                        result["status"],
+                        f" — {result.get('error')}" if result.get("error") else "",
+                    )
+                # Persist action results alongside the task record
+                await self._task_svc.update_status(
+                    task["id"],
+                    status=task_status.value,
+                    actions=action_results,
+                )
 
             metric_status = (
                 "failed" if task_status == TaskStatus.Failed else "processed"

--- a/runtime/tests/test_consumer.py
+++ b/runtime/tests/test_consumer.py
@@ -2,7 +2,7 @@
 import json
 import pytest
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from kape_runtime.consumer import ConsumerLoop
 from kape_runtime.models import TaskStatus
 
@@ -26,6 +26,21 @@ def _fresh_cloud_event() -> dict:
         "datacontenttype": "application/json",
         "data": {"alertname": "TestAlert"},
     }
+
+
+def _make_kape_cfg(**overrides) -> MagicMock:
+    """Create a KapeConfig mock with safe defaults (no actions by default)."""
+    defaults = dict(
+        handler_name="test",
+        handler_namespace="default",
+        cluster_name="kind-local",
+        dry_run=False,
+        max_event_age_seconds=300,
+        schema_name="test-schema",
+        actions=[],
+    )
+    defaults.update(overrides)
+    return MagicMock(**defaults)
 
 
 CLOUD_EVENT = _fresh_cloud_event()
@@ -52,14 +67,7 @@ async def test_consumer_acks_message_before_processing():
     loop = ConsumerLoop(
         task_svc=mock_task_svc,
         graph=mock_graph,
-        kape_cfg=MagicMock(
-            handler_name="test",
-            handler_namespace="default",
-            cluster_name="kind-local",
-            dry_run=False,
-            max_event_age_seconds=300,
-            schema_name="test-schema",
-        ),
+        kape_cfg=_make_kape_cfg(),
     )
 
     await loop.process_message(msg)
@@ -87,14 +95,7 @@ async def test_consumer_marks_unprocessable_on_bad_json():
     loop = ConsumerLoop(
         task_svc=mock_task_svc,
         graph=AsyncMock(),
-        kape_cfg=MagicMock(
-            handler_name="test",
-            handler_namespace="default",
-            cluster_name="kind-local",
-            dry_run=False,
-            max_event_age_seconds=300,
-            schema_name="test-schema",
-        ),
+        kape_cfg=_make_kape_cfg(),
     )
 
     await loop.process_message(msg)
@@ -116,14 +117,7 @@ async def test_consumer_deletes_task_on_stale_event():
     loop = ConsumerLoop(
         task_svc=mock_task_svc,
         graph=AsyncMock(),
-        kape_cfg=MagicMock(
-            handler_name="test",
-            handler_namespace="default",
-            cluster_name="kind-local",
-            dry_run=False,
-            max_event_age_seconds=300,
-            schema_name="test-schema",
-        ),
+        kape_cfg=_make_kape_cfg(),
     )
 
     await loop.process_message(msg)
@@ -147,14 +141,7 @@ async def test_consumer_writes_failed_on_unhandled_exception():
     loop = ConsumerLoop(
         task_svc=mock_task_svc,
         graph=mock_graph,
-        kape_cfg=MagicMock(
-            handler_name="test",
-            handler_namespace="default",
-            cluster_name="kind-local",
-            dry_run=False,
-            max_event_age_seconds=300,
-            schema_name="test-schema",
-        ),
+        kape_cfg=_make_kape_cfg(),
     )
 
     await loop.process_message(msg)
@@ -163,3 +150,158 @@ async def test_consumer_writes_failed_on_unhandled_exception():
     assert update_kwargs["status"] == "Failed"
     assert update_kwargs["error"]["type"] == "UnhandledError"
     assert "unexpected crash" in update_kwargs["error"]["detail"]
+
+
+# --- Actions router wiring tests ---
+
+@pytest.mark.asyncio
+async def test_consumer_dispatches_actions_after_graph_completion():
+    """run_actions is called after graph completes when actions are configured."""
+    action_cfg = {
+        "name": "notify-webhook",
+        "type": "webhook",
+        "url": "http://example.test/hook",
+        "body_template": '{"decision": "{{ decision }}"}',
+    }
+    schema_output = {"decision": "ignore", "confidence": 0.9, "reasoning": "all good"}
+
+    msg = make_nats_msg(CLOUD_EVENT)
+
+    mock_task_svc = AsyncMock()
+    mock_task_svc.create.return_value = {"id": "01TASK"}
+    mock_task_svc.update_status = AsyncMock()
+
+    mock_graph = AsyncMock()
+    mock_graph.ainvoke.return_value = {
+        "task_status": TaskStatus.Completed,
+        "schema_output": schema_output,
+        "parse_error": None,
+        "messages": [],
+        "action_results": [],
+        "should_abort": False,
+    }
+
+    fake_action_results = [{"name": "notify-webhook", "type": "webhook", "status": "success"}]
+
+    with patch("kape_runtime.consumer.run_actions", new=AsyncMock(return_value=fake_action_results)) as mock_run_actions:
+        loop = ConsumerLoop(
+            task_svc=mock_task_svc,
+            graph=mock_graph,
+            kape_cfg=_make_kape_cfg(actions=[action_cfg]),
+        )
+        await loop.process_message(msg)
+
+    mock_run_actions.assert_awaited_once()
+    call_kwargs = mock_run_actions.call_args.kwargs
+    assert call_kwargs["schema_output"] == schema_output
+    assert call_kwargs["actions"] == [action_cfg]
+    assert call_kwargs["handler_name"] == "test"
+    assert call_kwargs["task_id"] == "01TASK"
+
+    # The second update_status call should include the action results
+    assert mock_task_svc.update_status.await_count == 2
+    second_call_kwargs = mock_task_svc.update_status.call_args_list[1].kwargs
+    assert second_call_kwargs["actions"] == fake_action_results
+    assert second_call_kwargs["status"] == "Completed"
+
+
+@pytest.mark.asyncio
+async def test_consumer_skips_actions_when_schema_output_is_none():
+    """Actions are NOT dispatched when schema_output is None (parse failure path)."""
+    msg = make_nats_msg(CLOUD_EVENT)
+
+    mock_task_svc = AsyncMock()
+    mock_task_svc.create.return_value = {"id": "01TASK"}
+    mock_task_svc.update_status = AsyncMock()
+
+    mock_graph = AsyncMock()
+    mock_graph.ainvoke.return_value = {
+        "task_status": TaskStatus.SchemaValidationFailed,
+        "schema_output": None,
+        "parse_error": "LLM refused to produce JSON",
+        "messages": [],
+        "action_results": [],
+        "should_abort": True,
+    }
+
+    action_cfg = {"name": "noop", "type": "webhook", "url": "http://x/y", "body_template": "{}"}
+
+    with patch("kape_runtime.consumer.run_actions", new=AsyncMock()) as mock_run_actions:
+        loop = ConsumerLoop(
+            task_svc=mock_task_svc,
+            graph=mock_graph,
+            kape_cfg=_make_kape_cfg(actions=[action_cfg]),
+        )
+        await loop.process_message(msg)
+
+    mock_run_actions.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_consumer_skips_actions_when_no_actions_configured():
+    """Actions are NOT dispatched when kape_cfg.actions is empty."""
+    schema_output = {"decision": "ignore", "confidence": 0.9, "reasoning": "OK"}
+    msg = make_nats_msg(CLOUD_EVENT)
+
+    mock_task_svc = AsyncMock()
+    mock_task_svc.create.return_value = {"id": "01TASK"}
+    mock_task_svc.update_status = AsyncMock()
+
+    mock_graph = AsyncMock()
+    mock_graph.ainvoke.return_value = {
+        "task_status": TaskStatus.Completed,
+        "schema_output": schema_output,
+        "parse_error": None,
+        "messages": [],
+        "action_results": [],
+        "should_abort": False,
+    }
+
+    with patch("kape_runtime.consumer.run_actions", new=AsyncMock()) as mock_run_actions:
+        loop = ConsumerLoop(
+            task_svc=mock_task_svc,
+            graph=mock_graph,
+            kape_cfg=_make_kape_cfg(actions=[]),  # no actions
+        )
+        await loop.process_message(msg)
+
+    mock_run_actions.assert_not_awaited()
+    # Only one update_status call — no second call for actions
+    mock_task_svc.update_status.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_consumer_propagates_parent_task_id_from_event_extension():
+    """parent_task_id is extracted from CloudEvent extensions and passed to run_actions."""
+    event_with_parent = {
+        **CLOUD_EVENT,
+        "parent_task_id": "PARENT-01",
+    }
+    msg = make_nats_msg(event_with_parent)
+
+    mock_task_svc = AsyncMock()
+    mock_task_svc.create.return_value = {"id": "01TASK"}
+    mock_task_svc.update_status = AsyncMock()
+
+    mock_graph = AsyncMock()
+    mock_graph.ainvoke.return_value = {
+        "task_status": TaskStatus.Completed,
+        "schema_output": {"decision": "investigate", "confidence": 0.8, "reasoning": "chain"},
+        "parse_error": None,
+        "messages": [],
+        "action_results": [],
+        "should_abort": False,
+    }
+
+    action_cfg = {"name": "chain-event", "type": "event-publish", "subject": "kape.out"}
+
+    with patch("kape_runtime.consumer.run_actions", new=AsyncMock(return_value=[])) as mock_run_actions:
+        loop = ConsumerLoop(
+            task_svc=mock_task_svc,
+            graph=mock_graph,
+            kape_cfg=_make_kape_cfg(actions=[action_cfg]),
+        )
+        await loop.process_message(msg)
+
+    call_kwargs = mock_run_actions.call_args.kwargs
+    assert call_kwargs["parent_task_id"] == "PARENT-01"


### PR DESCRIPTION
## Summary

- The Phase 7 closeout audit found that `run_actions()` from `kape_runtime.actions.router` was fully implemented and unit-tested in #73 but **never called** from `consumer.py` — the entire post-decision action layer (event-publish, webhook, save_memory) was dead code at runtime
- This PR wires the actions router into the consumer's message-processing loop, completing the P7/05 integration and unblocking the M3 two-handler chain gate

## Audit reference

Audit finding from Phase 7 closeout: *"P7/05 ActionsRouter not called: `run_actions` from `kape_runtime.actions.router` is never invoked after the respond node completes"*

## Why the gap existed

The #73 slice was merged with the router + per-handler unit tests in place, but the integration step (calling `run_actions` from the consumer after graph completion) was deferred and never tracked as a follow-up. The issue was closed when the implementation unit tests passed.

## Integration point chosen

`run_actions()` is called in `ConsumerLoop.process_message()` **after** `graph.ainvoke()` returns and the initial `update_status()` succeeds, guarded by `schema_output is not None and kape_cfg.actions`. This is the natural integration point: schema_output is confirmed present, the task record is created, and the NATS client (`self._nc`) is available. A second `update_status()` call persists the action results alongside the task record.

## Files changed

| File | Change |
|------|--------|
| `runtime/src/kape_runtime/consumer.py` | Import `run_actions`; add `qdrant_client` param to `ConsumerLoop`; call `run_actions` post-graph with logging + result persistence (+32 lines) |
| `runtime/src/kape_runtime/config.py` | Add `actions: list[dict]` field to `KapeConfig` (default `[]`); load from `[kape.actions]` in settings (+10 lines) |
| `runtime/tests/test_consumer.py` | Refactor to `_make_kape_cfg()` helper; add 4 new tests covering dispatch, skip-on-None, skip-on-empty, parent_task_id propagation (+175 lines) |

## Test coverage added

- `test_consumer_dispatches_actions_after_graph_completion` — verifies `run_actions` is called with correct args and results are persisted
- `test_consumer_skips_actions_when_schema_output_is_none` — parse failure path: no action dispatch
- `test_consumer_skips_actions_when_no_actions_configured` — empty actions list: only one `update_status` call
- `test_consumer_propagates_parent_task_id_from_event_extension` — CloudEvent `parent_task_id` extension flows through correctly

All 62 tests pass (62 passed, 0 failed).

## Snyk

11 findings, all pre-existing `Jinja2AutoEscapeFalse` in the actions handlers (`event_emitter.py`, `webhook.py`, `save_memory.py`) and test files — 0 new findings introduced by this PR.

Closes #73