### PR TITLE
feat(security): Phase 8.2 network policy reference manifests (#77)

### DIFF
--- a/examples/networkpolicy/README.md
+++ b/examples/networkpolicy/README.md
@@ -1,0 +1,144 @@
+# KAPE Network Policy Reference Manifests
+
+Reference NetworkPolicy manifests for the 5-boundary network isolation model.
+
+**Design spec:** `docs/superpowers/specs/2026-05-17-phase8-issue-77-network-policy-design.md`
+**Reference spec:** 0007 (security layer)
+**GitHub issue:** dzungtr/kape#77
+
+---
+
+## The 5-Boundary Model
+
+| # | Name | Policy type | Direction | Load-bearing rule |
+|---|------|-------------|-----------|-------------------|
+| 1 | Handler pod egress | Egress on handler pods | Outbound | Private CIDR exclusion on 443 forces MCP through sidecar |
+| 2 | kapetool sidecar egress | Egress on handler pods (per-tool label) | Outbound | Per-KapeTool policy restricts pod to one MCP server |
+| 3 | MCP server ingress | Ingress on MCP server pods | Inbound | Only handler pods in kape-system may connect |
+| 4 | kape-task-service ingress | Ingress on task-service pods | Inbound | Only handler and dashboard pods may connect |
+| 5 | postgres ingress | Ingress on postgres pods | Inbound | Only task-service pods may connect |
+
+The full architectural rationale and boundary diagrams are in the design spec and spec 0007 section 2.
+
+---
+
+## Directory Layout
+
+```
+examples/networkpolicy/
+  standard/          Standard Kubernetes NetworkPolicy API (CNI-agnostic)
+    handler-egress.yaml
+    kapetool-egress.yaml
+    mcp-server-ingress.yaml
+    task-service-ingress.yaml
+    postgres-ingress.yaml
+  cilium/            CiliumNetworkPolicy (requires Cilium CNI)
+    handler-egress.yaml
+    kapetool-egress.yaml
+    mcp-server-ingress.yaml
+    task-service-ingress.yaml
+    postgres-ingress.yaml
+  README.md          (this file)
+```
+
+---
+
+## Standard vs Cilium Variant
+
+Use `standard/` when your cluster runs any NetworkPolicy-capable CNI (Calico, Flannel
+with network policy add-on, etc.). These manifests use only the `networking.k8s.io/v1`
+API and are portable across CNIs.
+
+Use `cilium/` when your cluster runs Cilium. The Cilium variant is strictly stronger
+(per D2 in the design spec):
+
+- Handler egress to LLM providers is restricted by FQDN (`api.anthropic.com`,
+  `api.openai.com`) rather than port only. A compromised handler pod cannot reach
+  arbitrary internet hosts on port 443 — only the named endpoints are reachable.
+- Cluster-internal deny is expressed as an explicit `egressDeny` to the `cluster`
+  entity rather than private CIDR exclusions, which is more explicit and harder to
+  misconfigure.
+
+Do not mix standard and Cilium manifests in the same cluster.
+
+---
+
+## Required Pod Labels
+
+Engineers must set the following labels on their pods before applying these policies.
+
+| Label | Value | Who sets it | Applied to |
+|-------|-------|-------------|------------|
+| `kape.io/component` | `nats` | Engineer | NATS pods |
+| `kape.io/component` | `task-service` | Engineer | kape-task-service pods |
+| `kape.io/component` | `dashboard` | Engineer | Dashboard pods |
+| `kape.io/component` | `postgres` | Engineer | Postgres pods |
+| `kape.io/mcp-server` | `<server-name>` | Engineer | MCP server pods |
+
+The operator sets the following labels automatically at Deployment creation time:
+
+| Label | Value | Who sets it | Applied to |
+|-------|-------|-------------|------------|
+| `kape.io/component` | `handler` | Operator | Handler pods |
+| `kape.io/tool` | `<tool-name>` | Operator | Handler pods (per KapeTool) |
+
+---
+
+## kapetool-egress.yaml is a Template
+
+`kapetool-egress.yaml` is an example for the KapeTool named `k8s-mcp-read`. It is
+**not** a singleton — you must create one NetworkPolicy per KapeTool instance (per D4
+in the design spec).
+
+To add a KapeTool:
+
+1. Copy `kapetool-egress.yaml` (or `cilium/kapetool-egress.yaml`).
+2. Change `metadata.name` to `kape-kapetool-egress-<tool-name>`.
+3. Change `kape.io/tool: k8s-mcp-read` to `kape.io/tool: <tool-name>`.
+4. Change `kape.io/mcp-server: k8s-mcp` to `kape.io/mcp-server: <server-name>`.
+5. Apply the new manifest.
+
+---
+
+## No Default-Deny Shipped
+
+These manifests are additive allowances. A cluster-wide default-deny NetworkPolicy is
+**not** included (per D7 in the design spec). Engineers must apply a deny-all baseline
+independently as part of their cluster setup. The policies here are meaningless without
+a pre-existing deny posture.
+
+---
+
+## Applying the Manifests
+
+### Standard variant
+
+```bash
+# Dry-run (server-side) — verify the API server accepts all manifests
+kubectl apply --dry-run=server -f examples/networkpolicy/standard/
+
+# Apply
+kubectl apply -f examples/networkpolicy/standard/
+```
+
+### Cilium variant
+
+```bash
+# Dry-run (server-side) — requires Cilium CRDs to be installed
+kubectl apply --dry-run=server -f examples/networkpolicy/cilium/
+
+# Apply
+kubectl apply -f examples/networkpolicy/cilium/
+```
+
+---
+
+## Live-Cluster Verification
+
+The acceptance criteria and step-by-step verification commands (boundaries 1-5) are
+documented in the design spec:
+
+`docs/superpowers/specs/2026-05-17-phase8-issue-77-network-policy-design.md`
+
+See the "Acceptance Criteria" and "Testing Strategy" sections for boundary-by-boundary
+`kubectl exec` checks and expected pass/fail outcomes.

--- a/examples/networkpolicy/cilium/handler-egress.yaml
+++ b/examples/networkpolicy/cilium/handler-egress.yaml
@@ -1,0 +1,58 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kape-handler-egress
+  namespace: kape-system
+  annotations:
+    kape.io/doc: >
+      Boundary 1 — Handler pod egress (Cilium variant).
+      Stronger than standard: LLM egress is FQDN-restricted, not port-only.
+      The egressDeny to 'cluster' blocks all cluster-internal egress except
+      the explicit NATS and task-service rules below.
+spec:
+  endpointSelector:
+    matchLabels:
+      kape.io/component: handler
+  # Block all cluster-internal egress by default.
+  # MCP traffic must go through the kapetool sidecar on localhost (exempt from
+  # NetworkPolicy as a loopback interface).
+  egressDeny:
+    - toEntities:
+        - cluster
+  egress:
+    # NATS JetStream — whitelisted cluster-internal destination
+    - toEndpoints:
+        - matchLabels:
+            kape.io/component: nats
+      toPorts:
+        - ports:
+            - port: "4222"
+              protocol: TCP
+
+    # kape-task-service — whitelisted cluster-internal destination
+    - toEndpoints:
+        - matchLabels:
+            kape.io/component: task-service
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+
+    # LLM provider — FQDN-restricted internet egress.
+    # Only Anthropic and OpenAI endpoints are permitted.
+    # Add additional FQDNs here if your deployment uses other LLM providers.
+    - toFQDNs:
+        - matchName: "api.anthropic.com"
+        - matchName: "api.openai.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+
+    # DNS — required for FQDN resolution
+    - toEntities:
+        - kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP

--- a/examples/networkpolicy/cilium/kapetool-egress.yaml
+++ b/examples/networkpolicy/cilium/kapetool-egress.yaml
@@ -1,0 +1,25 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kape-kapetool-egress-k8s-mcp-read
+  namespace: kape-system
+  annotations:
+    kape.io/doc: >
+      Boundary 2 — kapetool sidecar egress for k8s-mcp-read (Cilium variant).
+      Functionally equivalent to the standard variant. Uses Cilium endpoint
+      selectors for consistent policy model with the handler-egress policy.
+spec:
+  endpointSelector:
+    matchLabels:
+      kape.io/component: handler
+      kape.io/tool: k8s-mcp-read
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            kape.io/mcp-server: k8s-mcp
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+            - port: "8081"
+              protocol: TCP

--- a/examples/networkpolicy/cilium/mcp-server-ingress.yaml
+++ b/examples/networkpolicy/cilium/mcp-server-ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kape-mcp-ingress
+  namespace: kape-system
+  annotations:
+    kape.io/doc: >
+      Boundary 3 — MCP server ingress (Cilium variant).
+      Permits inbound connections only from kape.io/component: handler pods
+      in kape-system. Cilium uses endpointSelector for the target pod and
+      fromEndpoints for the source constraint.
+spec:
+  endpointSelector:
+    matchLabels:
+      kape.io/mcp-server: k8s-mcp
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            kape.io/component: handler
+            k8s:io.kubernetes.pod.namespace: kape-system
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+            - port: "8081"
+              protocol: TCP

--- a/examples/networkpolicy/cilium/postgres-ingress.yaml
+++ b/examples/networkpolicy/cilium/postgres-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kape-postgres-ingress
+  namespace: kape-system
+  annotations:
+    kape.io/doc: >
+      Boundary 5 — postgres ingress (Cilium variant).
+spec:
+  endpointSelector:
+    matchLabels:
+      kape.io/component: postgres
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            kape.io/component: task-service
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/examples/networkpolicy/cilium/task-service-ingress.yaml
+++ b/examples/networkpolicy/cilium/task-service-ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kape-task-service-ingress
+  namespace: kape-system
+  annotations:
+    kape.io/doc: >
+      Boundary 4 — kape-task-service ingress (Cilium variant).
+spec:
+  endpointSelector:
+    matchLabels:
+      kape.io/component: task-service
+  ingress:
+    # Handler pods
+    - fromEndpoints:
+        - matchLabels:
+            kape.io/component: handler
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+
+    # Dashboard pods
+    - fromEndpoints:
+        - matchLabels:
+            kape.io/component: dashboard
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/examples/networkpolicy/standard/handler-egress.yaml
+++ b/examples/networkpolicy/standard/handler-egress.yaml
@@ -1,0 +1,60 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kape-handler-egress
+  namespace: kape-system
+  annotations:
+    kape.io/doc: >
+      Boundary 1 — Handler pod egress.
+      Permits NATS (4222), task-service (8080), and internet-only LLM API (443).
+      Private CIDR exclusions on the LLM rule are load-bearing: they force all
+      MCP traffic through the kapetool sidecar on localhost, not a direct
+      cluster-internal connection.
+spec:
+  podSelector:
+    matchLabels:
+      kape.io/component: handler
+  policyTypes:
+    - Egress
+  egress:
+    # NATS JetStream — event subscription and publication
+    - to:
+        - podSelector:
+            matchLabels:
+              kape.io/component: nats
+      ports:
+        - port: 4222
+          protocol: TCP
+
+    # kape-task-service — task status writes and audit log
+    - to:
+        - podSelector:
+            matchLabels:
+              kape.io/component: task-service
+      ports:
+        - port: 8080
+          protocol: TCP
+
+    # LLM provider (Anthropic / OpenAI) — internet egress on 443 only.
+    # Private IP ranges are excluded. This is the load-bearing security clause:
+    # all cluster-internal addresses fall within these CIDRs, so MCP servers
+    # cannot be reached directly from handler pods on port 443. MCP traffic
+    # must go through the kapetool sidecar on localhost (127.0.0.1), which is
+    # not a network hop subject to NetworkPolicy.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP
+
+    # DNS — required for hostname resolution (NATS service name, task-service, etc.)
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP

--- a/examples/networkpolicy/standard/kapetool-egress.yaml
+++ b/examples/networkpolicy/standard/kapetool-egress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kape-kapetool-egress-k8s-mcp-read
+  namespace: kape-system
+  annotations:
+    kape.io/doc: >
+      Boundary 2 — kapetool sidecar egress for k8s-mcp-read.
+      One NetworkPolicy per KapeTool instance. The operator sets
+      kape.io/tool: <tool-name> on handler pods. Engineers label
+      their MCP server pods with kape.io/mcp-server: <server-name>.
+      Duplicate this manifest for each additional KapeTool, changing
+      the name, kape.io/tool selector, and kape.io/mcp-server selector.
+spec:
+  podSelector:
+    matchLabels:
+      kape.io/component: handler
+      kape.io/tool: k8s-mcp-read   # operator sets this on handler pods at Deployment creation
+  policyTypes:
+    - Egress
+  egress:
+    # MCP server — both SSE (:8080) and Streamable HTTP (:8081) transports.
+    # Engineers label MCP server pods with kape.io/mcp-server: <server-name>.
+    - to:
+        - podSelector:
+            matchLabels:
+              kape.io/mcp-server: k8s-mcp   # engineer sets this on MCP server pods
+      ports:
+        - port: 8080
+          protocol: TCP
+        - port: 8081
+          protocol: TCP

--- a/examples/networkpolicy/standard/mcp-server-ingress.yaml
+++ b/examples/networkpolicy/standard/mcp-server-ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kape-mcp-ingress
+  namespace: kape-system   # adjust to the namespace where your MCP server is deployed
+  annotations:
+    kape.io/doc: >
+      Boundary 3 — MCP server ingress.
+      Permits inbound connections only from kape.io/component: handler pods
+      in the kape-system namespace. The namespaceSelector + podSelector
+      combination uses AND semantics — both conditions must match.
+      Engineer must set kape.io/mcp-server: <server-name> on MCP server pods.
+      Adjust the podSelector.matchLabels to match your MCP server's label.
+spec:
+  podSelector:
+    matchLabels:
+      kape.io/mcp-server: k8s-mcp   # engineer sets this on their MCP server pods
+  policyTypes:
+    - Ingress
+  ingress:
+    # Accept connections only from handler pods in kape-system.
+    # namespaceSelector + podSelector in the same 'from' entry = AND semantics.
+    - from:
+        - podSelector:
+            matchLabels:
+              kape.io/component: handler
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kape-system
+      ports:
+        - port: 8080
+          protocol: TCP   # SSE transport
+        - port: 8081
+          protocol: TCP   # Streamable HTTP transport

--- a/examples/networkpolicy/standard/postgres-ingress.yaml
+++ b/examples/networkpolicy/standard/postgres-ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kape-postgres-ingress
+  namespace: kape-system
+  annotations:
+    kape.io/doc: >
+      Boundary 5 — postgres ingress.
+      Accepts connections only from kape-task-service. This enforces the v1
+      single-accessor model: no handler pod, dashboard pod, or operator pod
+      has a permitted network path to postgres. The REST API of task-service
+      is the complete audit boundary (spec 0007 section 9).
+spec:
+  podSelector:
+    matchLabels:
+      kape.io/component: postgres
+  policyTypes:
+    - Ingress
+  ingress:
+    # Only kape-task-service may connect to postgres
+    - from:
+        - podSelector:
+            matchLabels:
+              kape.io/component: task-service
+      ports:
+        - port: 5432
+          protocol: TCP

--- a/examples/networkpolicy/standard/task-service-ingress.yaml
+++ b/examples/networkpolicy/standard/task-service-ingress.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kape-task-service-ingress
+  namespace: kape-system
+  annotations:
+    kape.io/doc: >
+      Boundary 4 — kape-task-service ingress.
+      Accepts connections from handler pods (task writes) and dashboard pods
+      (task reads). All other ingress — including direct database clients and
+      operator pods — is denied. This policy is load-bearing for audit log
+      isolation: the REST API surface is the complete audit boundary.
+spec:
+  podSelector:
+    matchLabels:
+      kape.io/component: task-service
+  policyTypes:
+    - Ingress
+  ingress:
+    # Handler pods — task status writes and schema output persistence
+    - from:
+        - podSelector:
+            matchLabels:
+              kape.io/component: handler
+      ports:
+        - port: 8080
+          protocol: TCP
+
+    # Dashboard pods — task reads and status queries
+    - from:
+        - podSelector:
+            matchLabels:
+              kape.io/component: dashboard
+      ports:
+        - port: 8080
+          protocol: TCP


### PR DESCRIPTION
## Summary

- Adds reference NetworkPolicy manifests under `examples/networkpolicy/` implementing the full 5-boundary network isolation model from spec 0007 §2, in both standard Kubernetes NetworkPolicy and Cilium dialects.
- Boundaries: (1) handler egress, (2) per-KapeTool kapetool sidecar egress, (3) MCP server ingress, (4) task-service ingress, (5) postgres ingress.
- Standard variant enforces "MCP must go through the localhost sidecar" via private-CIDR exclusion on the LLM 443 rule (load-bearing per design spec D3). Cilium variant is strictly stronger — LLM egress FQDN-restricted to `api.anthropic.com` / `api.openai.com`, with `egressDeny: cluster`.
- Operator does **not** auto-generate these (D5). No default-deny ships in this PR (D7) — engineers apply a cluster baseline separately.

## Design spec

`docs/superpowers/specs/2026-05-17-phase8-issue-77-network-policy-design.md` — contains diagram, per-boundary rationale, design decisions D1–D7, and acceptance criteria.

## Files

```
examples/networkpolicy/
  README.md
  standard/   {handler,kapetool,mcp-server,task-service,postgres}-{egress,ingress}.yaml
  cilium/     {handler,kapetool,mcp-server,task-service,postgres}-{egress,ingress}.yaml
```

YAML content was copied verbatim from the spec — comments and `kape.io/doc` annotations are load-bearing per D3 and D6.

## Test plan

- [x] All 10 manifests parse cleanly with `yq`
- [x] All 5 standard manifests pass `kubectl apply --dry-run=client` and `--dry-run=server` against a live cluster
- [x] Cilium manifests parse with `yq`; server dry-run requires Cilium CRDs (expected — out of scope for this PR)
- [ ] Live boundary verification against a real cluster per acceptance criteria in the design spec — deferred to cluster-integration testing

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)