### PR TITLE
feat(phase8): mTLS for NATS — cert-manager + helper + handler injection (#81)

### DIFF
--- a/adapters/cmd/alertmanager/main.go
+++ b/adapters/cmd/alertmanager/main.go
@@ -33,11 +33,11 @@ func main() {
 	port := envOr("PORT", "8080")
 	publishTTL := envDuration("PUBLISH_TIMEOUT_SECONDS", 60)
 
-	nc, err := natsgo.Connect(natsURL,
-		natsgo.Name("kape-alertmanager-adapter"),
-		natsgo.MaxReconnects(-1),
-		natsgo.ReconnectWait(2*time.Second),
-	)
+	tlsCert := os.Getenv("NATS_TLS_CERT")
+	tlsKey := os.Getenv("NATS_TLS_KEY")
+	tlsCA := os.Getenv("NATS_TLS_CA")
+
+	nc, err := natspkg.Connect(natsURL, "kape-alertmanager-adapter", tlsCert, tlsKey, tlsCA)
 	if err != nil {
 		log.Fatal().Err(err).Str("nats_url", natsURL).Msg("failed to connect to NATS")
 	}

--- a/adapters/internal/nats/connect.go
+++ b/adapters/internal/nats/connect.go
@@ -1,0 +1,62 @@
+package nats
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"time"
+
+	natsgo "github.com/nats-io/nats.go"
+	"github.com/rs/zerolog/log"
+)
+
+// Connect establishes a NATS connection. If certFile, keyFile, and caFile are
+// all non-empty, mTLS is configured using those paths. If any of the three
+// values is empty, the connection is made without TLS and a warning is logged
+// (local dev / CI fallback only — production deployments must set all three).
+func Connect(url, name, certFile, keyFile, caFile string) (*natsgo.Conn, error) {
+	opts := []natsgo.Option{
+		natsgo.Name(name),
+		natsgo.MaxReconnects(-1),
+		natsgo.ReconnectWait(2 * time.Second),
+	}
+
+	if certFile != "" && keyFile != "" && caFile != "" {
+		tlsCfg, err := buildTLSConfig(certFile, keyFile, caFile)
+		if err != nil {
+			return nil, fmt.Errorf("building TLS config: %w", err)
+		}
+		opts = append(opts, natsgo.Secure(tlsCfg))
+		log.Info().
+			Str("cert", certFile).
+			Str("ca", caFile).
+			Msg("mTLS enabled for NATS connection")
+	} else {
+		log.Warn().Msg("NATS_TLS_CERT / NATS_TLS_KEY / NATS_TLS_CA not set — connecting without mTLS (local dev only)")
+	}
+
+	return natsgo.Connect(url, opts...)
+}
+
+func buildTLSConfig(certFile, keyFile, caFile string) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("loading client key pair: %w", err)
+	}
+
+	caPEM, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading CA cert %s: %w", caFile, err)
+	}
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("parsing CA cert from %s", caFile)
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caPool,
+		MinVersion:   tls.VersionTLS13,
+	}, nil
+}

--- a/adapters/internal/nats/connect_test.go
+++ b/adapters/internal/nats/connect_test.go
@@ -1,0 +1,137 @@
+package nats
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generateTestCerts creates a self-signed CA and a leaf cert signed by it.
+// Returns paths to ca.crt, tls.crt, tls.key written under dir.
+func generateTestCerts(t *testing.T, dir string) (caPath, certPath, keyPath string) {
+	t.Helper()
+
+	// CA key + cert
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "test-ca",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	caPath = filepath.Join(dir, "ca.crt")
+	caFile, err := os.Create(caPath)
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(caFile, &pem.Block{Type: "CERTIFICATE", Bytes: caDER}))
+	caFile.Close()
+
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	// Leaf key + cert
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: "test-leaf",
+		},
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(24 * time.Hour),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageClientAuth,
+		},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	certPath = filepath.Join(dir, "tls.crt")
+	certFile, err := os.Create(certPath)
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: leafDER}))
+	certFile.Close()
+
+	keyPath = filepath.Join(dir, "tls.key")
+	keyFile, err := os.Create(keyPath)
+	require.NoError(t, err)
+	leafKeyDER, err := x509.MarshalECPrivateKey(leafKey)
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(keyFile, &pem.Block{Type: "EC PRIVATE KEY", Bytes: leafKeyDER}))
+	keyFile.Close()
+
+	return caPath, certPath, keyPath
+}
+
+func TestBuildTLSConfig_Success(t *testing.T) {
+	dir := t.TempDir()
+	caPath, certPath, keyPath := generateTestCerts(t, dir)
+
+	cfg, err := buildTLSConfig(certPath, keyPath, caPath)
+	require.NoError(t, err)
+	assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
+	assert.Len(t, cfg.Certificates, 1)
+	assert.NotNil(t, cfg.RootCAs)
+}
+
+func TestBuildTLSConfig_MissingCAFile(t *testing.T) {
+	dir := t.TempDir()
+	_, certPath, keyPath := generateTestCerts(t, dir)
+
+	_, err := buildTLSConfig(certPath, keyPath, filepath.Join(dir, "nonexistent-ca.crt"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading CA cert")
+}
+
+func TestBuildTLSConfig_InvalidCAFile(t *testing.T) {
+	dir := t.TempDir()
+	_, certPath, keyPath := generateTestCerts(t, dir)
+
+	// Write a non-PEM file as CA
+	invalidCA := filepath.Join(dir, "invalid-ca.crt")
+	require.NoError(t, os.WriteFile(invalidCA, []byte("not valid PEM data"), 0o600))
+
+	_, err := buildTLSConfig(certPath, keyPath, invalidCA)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing CA cert")
+}
+
+func TestBuildTLSConfig_InvalidKeyPair(t *testing.T) {
+	dir := t.TempDir()
+	caPath, _, _ := generateTestCerts(t, dir)
+
+	_, err := buildTLSConfig(filepath.Join(dir, "nonexistent.crt"), filepath.Join(dir, "nonexistent.key"), caPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loading client key pair")
+}
+
+func TestConnect_NoTLS_AttemptsPlain(t *testing.T) {
+	// Call Connect with empty TLS paths to an invalid URL — exercises the no-TLS
+	// branch. nats.Connect with MaxReconnects(-1) would retry forever, so we use
+	// a port that immediately refuses to keep the test fast.
+	_, err := Connect("nats://127.0.0.1:1", "test-no-tls", "", "", "")
+	assert.Error(t, err)
+}

--- a/examples/certs/issuer.yaml
+++ b/examples/certs/issuer.yaml
@@ -1,0 +1,34 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: kape-ca
+spec:
+  selfSigned: {}
+---
+# Self-signed CA certificate — ClusterIssuer signs itself, then becomes the
+# issuer for all kape-* certificates below.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kape-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: kape-ca
+  secretName: kape-ca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: kape-ca
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+# ClusterIssuer backed by the CA certificate above
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: kape-ca-issuer
+spec:
+  ca:
+    secretName: kape-ca-secret

--- a/examples/certs/nats-client-adapter-cert.yaml
+++ b/examples/certs/nats-client-adapter-cert.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kape-adapter-cert
+  namespace: kape-system
+spec:
+  secretName: kape-adapter-cert
+  commonName: kape-adapter     # MUST match authorization.users[].user in NATS config
+  duration: 8760h
+  renewBefore: 720h
+  usages:
+    - client auth
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: kape-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/examples/certs/nats-client-handler-cert.yaml
+++ b/examples/certs/nats-client-handler-cert.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kape-handler-cert
+  namespace: kape-system
+spec:
+  secretName: kape-handler-cert
+  commonName: kape-handler     # MUST match authorization.users[].user in NATS config
+  duration: 8760h
+  renewBefore: 720h
+  usages:
+    - client auth
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: kape-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/examples/certs/nats-server-cert.yaml
+++ b/examples/certs/nats-server-cert.yaml
@@ -1,0 +1,21 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kape-nats-server-cert
+  namespace: kape-system
+spec:
+  secretName: kape-nats-server-cert
+  commonName: nats-server
+  dnsNames:
+    - nats.kape-system.svc
+    - nats.kape-system.svc.cluster.local
+    - "*.nats-headless.kape-system.svc.cluster.local"  # StatefulSet pod DNS
+  duration: 8760h    # 1 year
+  renewBefore: 720h  # renew 30 days before expiry
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: kape-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/examples/nats/nats.yaml
+++ b/examples/nats/nats.yaml
@@ -1,0 +1,143 @@
+# NATS 2.10 JetStream server with mTLS enforcement — reference k8s manifest
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kape-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nats-config
+  namespace: kape-system
+data:
+  nats.conf: |
+    server_name: nats-0
+    listen: 0.0.0.0:4222
+    http: 0.0.0.0:8222
+
+    jetstream {
+      store_dir: /data
+      max_memory_store: 256Mi
+      max_file_store: 10Gi
+    }
+
+    tls {
+      ca_file:         /etc/nats/certs/ca.crt
+      cert_file:       /etc/nats/certs/tls.crt
+      key_file:        /etc/nats/certs/tls.key
+      verify:          true
+      verify_and_map:  true
+    }
+
+    authorization {
+      users: [
+        {
+          user: kape-adapter
+          permissions: {
+            publish:   { allow: ["kape.events.>"] }
+            subscribe: { deny: [">"] }
+          }
+        },
+        {
+          user: kape-handler
+          permissions: {
+            publish:   { allow: ["kape.events.>"] }
+            subscribe: { allow: ["kape.events.>"] }
+          }
+        }
+      ]
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+  namespace: kape-system
+spec:
+  type: ClusterIP
+  selector:
+    app: nats
+  ports:
+    - name: client
+      port: 4222
+      targetPort: 4222
+    - name: monitor
+      port: 8222
+      targetPort: 8222
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats-headless
+  namespace: kape-system
+spec:
+  clusterIP: None
+  selector:
+    app: nats
+  ports:
+    - name: client
+      port: 4222
+      targetPort: 4222
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: nats
+  namespace: kape-system
+spec:
+  serviceName: nats-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nats
+  template:
+    metadata:
+      labels:
+        app: nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.10-alpine
+          args: ["-c", "/etc/nats/config/nats.conf"]
+          ports:
+            - name: client
+              containerPort: 4222
+            - name: monitor
+              containerPort: 8222
+          readinessProbe:
+            tcpSocket:
+              port: 4222
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: nats-config
+              mountPath: /etc/nats/config
+              readOnly: true
+            - name: nats-server-tls
+              mountPath: /etc/nats/certs
+              readOnly: true
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: nats-config
+          configMap:
+            name: nats-config
+        - name: nats-server-tls
+          secret:
+            secretName: kape-nats-server-cert
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi

--- a/operator/infra/k8s/deployment.go
+++ b/operator/infra/k8s/deployment.go
@@ -26,6 +26,8 @@ func NewDeploymentAdapter(c client.Client) *DeploymentAdapter {
 	return &DeploymentAdapter{client: c}
 }
 
+const handlerCertSecretName = "kape-handler-cert"
+
 func deploymentName(handlerName string) string { return "kape-handler-" + handlerName }
 
 // Ensure creates or patches the handler Deployment with a single kapeproxy sidecar.
@@ -93,6 +95,11 @@ func buildDeployment(handler *v1alpha1.KapeHandler, cfg domainconfig.KapeConfig,
 		{Name: "KAPE_HANDLER_NAME", Value: handler.Name},
 		{Name: "KAPE_NAMESPACE", Value: handler.Namespace},
 	}
+	envVars = append(envVars,
+		corev1.EnvVar{Name: "NATS_TLS_CERT", Value: "/etc/kape/nats-certs/tls.crt"},
+		corev1.EnvVar{Name: "NATS_TLS_KEY", Value: "/etc/kape/nats-certs/tls.key"},
+		corev1.EnvVar{Name: "NATS_TLS_CA", Value: "/etc/kape/nats-certs/ca.crt"},
+	)
 	envVars = append(envVars, handler.Spec.Envs...)
 
 	handlerVolumeMounts := []corev1.VolumeMount{{
@@ -100,6 +107,11 @@ func buildDeployment(handler *v1alpha1.KapeHandler, cfg domainconfig.KapeConfig,
 		MountPath: "/etc/kape",
 		ReadOnly:  true,
 	}}
+	handlerVolumeMounts = append(handlerVolumeMounts, corev1.VolumeMount{
+		Name:      "nats-certs",
+		MountPath: "/etc/kape/nats-certs",
+		ReadOnly:  true,
+	})
 	volumes := []corev1.Volume{{
 		Name: "settings",
 		VolumeSource: corev1.VolumeSource{
@@ -108,6 +120,14 @@ func buildDeployment(handler *v1alpha1.KapeHandler, cfg domainconfig.KapeConfig,
 			},
 		},
 	}}
+	volumes = append(volumes, corev1.Volume{
+		Name: "nats-certs",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: handlerCertSecretName,
+			},
+		},
+	})
 
 	if lazySkillsPresent {
 		handlerVolumeMounts = append(handlerVolumeMounts, corev1.VolumeMount{

--- a/operator/infra/k8s/deployment_test.go
+++ b/operator/infra/k8s/deployment_test.go
@@ -207,3 +207,57 @@ func TestDeploymentAdapter_HandlerResources_OverrideFromSpec(t *testing.T) {
 	assert.True(t, override.Limits[corev1.ResourceCPU].Equal(got.Limits[corev1.ResourceCPU]))
 	assert.True(t, override.Limits[corev1.ResourceMemory].Equal(got.Limits[corev1.ResourceMemory]))
 }
+
+func TestDeploymentAdapter_NATSCertWiring(t *testing.T) {
+	handler := &v1alpha1.KapeHandler{
+		ObjectMeta: metav1.ObjectMeta{Name: "h", Namespace: "kape-system", UID: "uid-h"},
+	}
+	c := fake.NewClientBuilder().WithScheme(newTestScheme()).Build()
+	require.NoError(t, k8sadapters.NewDeploymentAdapter(c).Ensure(context.Background(), handler, domainconfig.KapeConfig{}, "h-1", nil, false))
+
+	var dep appsv1.Deployment
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Name: "kape-handler-h", Namespace: "kape-system"}, &dep))
+
+	// (a) Pod spec must contain a Volume named "nats-certs" backed by kape-handler-cert Secret.
+	var natsCertsVolume *corev1.Volume
+	for i := range dep.Spec.Template.Spec.Volumes {
+		if dep.Spec.Template.Spec.Volumes[i].Name == "nats-certs" {
+			natsCertsVolume = &dep.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, natsCertsVolume, "volume nats-certs must exist in pod spec")
+	require.NotNil(t, natsCertsVolume.VolumeSource.Secret, "nats-certs volume must be a Secret volume")
+	assert.Equal(t, "kape-handler-cert", natsCertsVolume.VolumeSource.Secret.SecretName)
+
+	// (b) Handler container must have a VolumeMount named "nats-certs".
+	var handlerContainer *corev1.Container
+	for i := range dep.Spec.Template.Spec.Containers {
+		if dep.Spec.Template.Spec.Containers[i].Name == "handler" {
+			handlerContainer = &dep.Spec.Template.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, handlerContainer, "handler container must exist")
+
+	var natsCertsMount *corev1.VolumeMount
+	for i := range handlerContainer.VolumeMounts {
+		if handlerContainer.VolumeMounts[i].Name == "nats-certs" {
+			natsCertsMount = &handlerContainer.VolumeMounts[i]
+			break
+		}
+	}
+	require.NotNil(t, natsCertsMount, "handler container must have VolumeMount nats-certs")
+	assert.Equal(t, "/etc/kape/nats-certs", natsCertsMount.MountPath)
+	assert.True(t, natsCertsMount.ReadOnly)
+
+	// (c) Handler container must export NATS_TLS_CERT, NATS_TLS_KEY, NATS_TLS_CA.
+	envMap := make(map[string]string, len(handlerContainer.Env))
+	for _, e := range handlerContainer.Env {
+		envMap[e.Name] = e.Value
+	}
+	assert.Equal(t, "/etc/kape/nats-certs/tls.crt", envMap["NATS_TLS_CERT"])
+	assert.Equal(t, "/etc/kape/nats-certs/tls.key", envMap["NATS_TLS_KEY"])
+	assert.Equal(t, "/etc/kape/nats-certs/ca.crt", envMap["NATS_TLS_CA"])
+}

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -55,3 +55,4 @@ select = ["E", "F", "I"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+pythonpath = ["src"]

--- a/runtime/src/kape_runtime/consumer.py
+++ b/runtime/src/kape_runtime/consumer.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import ssl
 import traceback
 from datetime import datetime, timezone
 from typing import Any
@@ -45,6 +47,34 @@ _llm_retry = tenacity.retry(
     stop=tenacity.stop_after_attempt(5),
     reraise=True,
 )
+
+
+def _build_nats_tls_context() -> ssl.SSLContext | None:
+    """Build an SSL context for mTLS NATS connections.
+
+    Returns an SSLContext when NATS_TLS_CERT, NATS_TLS_KEY, and NATS_TLS_CA
+    are all set. Returns None when any variable is absent — caller connects
+    without TLS (local dev / CI only).
+    """
+    cert_file = os.environ.get("NATS_TLS_CERT")
+    key_file = os.environ.get("NATS_TLS_KEY")
+    ca_file = os.environ.get("NATS_TLS_CA")
+
+    if not all([cert_file, key_file, ca_file]):
+        logger.warning(
+            "NATS_TLS_CERT / NATS_TLS_KEY / NATS_TLS_CA not set — "
+            "connecting to NATS without mTLS (local dev only)"
+        )
+        return None
+
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+    ctx.load_verify_locations(cafile=ca_file)
+    ctx.load_cert_chain(certfile=cert_file, keyfile=key_file)
+    logger.info(
+        "mTLS enabled for NATS connection (cert=%s ca=%s)", cert_file, ca_file
+    )
+    return ctx
 
 
 class ConsumerLoop:
@@ -235,7 +265,11 @@ class ConsumerLoop:
 
     async def run(self, nats_cfg: NatsConfig) -> None:
         """Connect to NATS and run the pull consumer loop indefinitely."""
-        nc = await nats.connect(nats_cfg.url)
+        tls_ctx = _build_nats_tls_context()
+        connect_kwargs: dict = {"servers": [nats_cfg.url]}
+        if tls_ctx is not None:
+            connect_kwargs["tls"] = tls_ctx
+        nc = await nats.connect(**connect_kwargs)
         self._nc = nc
         js = nc.jetstream()
         sub = await js.pull_subscribe(

--- a/runtime/tests/test_consumer_tls.py
+++ b/runtime/tests/test_consumer_tls.py
@@ -1,0 +1,124 @@
+"""Tests for _build_nats_tls_context in consumer.py."""
+from __future__ import annotations
+
+import logging
+import shutil
+import ssl
+import subprocess
+
+import pytest
+
+from kape_runtime.consumer import _build_nats_tls_context
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_OPENSSL = shutil.which("openssl")
+
+
+def _generate_test_certs(tmp_path):
+    """Generate a self-signed CA + client cert/key in tmp_path using openssl.
+
+    Returns (ca_file, cert_file, key_file) as str paths, or raises
+    pytest.skip if openssl is unavailable.
+    """
+    if _OPENSSL is None:
+        pytest.skip("openssl not found on PATH — skipping cert-gen test")
+
+    ca_key = str(tmp_path / "ca.key")
+    ca_crt = str(tmp_path / "ca.crt")
+    tls_key = str(tmp_path / "tls.key")
+    tls_csr = str(tmp_path / "tls.csr")
+    tls_crt = str(tmp_path / "tls.crt")
+
+    # Generate CA key + self-signed cert
+    subprocess.check_call(
+        [_OPENSSL, "ecparam", "-name", "prime256v1", "-genkey", "-noout", "-out", ca_key],
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.check_call(
+        [
+            _OPENSSL, "req", "-new", "-x509",
+            "-key", ca_key,
+            "-out", ca_crt,
+            "-days", "1",
+            "-subj", "/CN=kape-test-ca",
+        ],
+        stderr=subprocess.DEVNULL,
+    )
+
+    # Generate client key + CSR
+    subprocess.check_call(
+        [_OPENSSL, "ecparam", "-name", "prime256v1", "-genkey", "-noout", "-out", tls_key],
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.check_call(
+        [
+            _OPENSSL, "req", "-new",
+            "-key", tls_key,
+            "-out", tls_csr,
+            "-subj", "/CN=kape-handler",
+        ],
+        stderr=subprocess.DEVNULL,
+    )
+
+    # Sign client cert with CA
+    subprocess.check_call(
+        [
+            _OPENSSL, "x509", "-req",
+            "-in", tls_csr,
+            "-CA", ca_crt,
+            "-CAkey", ca_key,
+            "-CAcreateserial",
+            "-out", tls_crt,
+            "-days", "1",
+        ],
+        stderr=subprocess.DEVNULL,
+    )
+
+    return ca_crt, tls_crt, tls_key
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_returns_none_when_env_unset(monkeypatch, caplog):
+    """Returns None and logs a warning when all three env vars are absent."""
+    monkeypatch.delenv("NATS_TLS_CERT", raising=False)
+    monkeypatch.delenv("NATS_TLS_KEY", raising=False)
+    monkeypatch.delenv("NATS_TLS_CA", raising=False)
+
+    with caplog.at_level(logging.WARNING, logger="kape_runtime.consumer"):
+        result = _build_nats_tls_context()
+
+    assert result is None
+    assert any("without mTLS" in record.message for record in caplog.records)
+
+
+def test_returns_none_when_one_env_missing(monkeypatch, caplog, tmp_path):
+    """Returns None when only two of the three env vars are set."""
+    monkeypatch.setenv("NATS_TLS_CERT", str(tmp_path / "tls.crt"))
+    monkeypatch.setenv("NATS_TLS_KEY", str(tmp_path / "tls.key"))
+    monkeypatch.delenv("NATS_TLS_CA", raising=False)
+
+    with caplog.at_level(logging.WARNING, logger="kape_runtime.consumer"):
+        result = _build_nats_tls_context()
+
+    assert result is None
+
+
+def test_returns_context_when_all_env_set(monkeypatch, tmp_path):
+    """Returns a valid SSLContext with TLS 1.3 minimum when all env vars are set."""
+    ca_crt, tls_crt, tls_key = _generate_test_certs(tmp_path)
+
+    monkeypatch.setenv("NATS_TLS_CERT", tls_crt)
+    monkeypatch.setenv("NATS_TLS_KEY", tls_key)
+    monkeypatch.setenv("NATS_TLS_CA", ca_crt)
+
+    result = _build_nats_tls_context()
+
+    assert isinstance(result, ssl.SSLContext)
+    assert result.minimum_version == ssl.TLSVersion.TLSv1_3


### PR DESCRIPTION
Implements GitHub issue #81 — Phase 8.6 mTLS for NATS — per the design at `docs/superpowers/specs/2026-05-17-phase8-issue-81-mtls-nats-design.md`.

Closes #81.

## Summary
- **cert-manager manifests** (`examples/certs/`): self-signed `kape-ca` ClusterIssuer + the NATS server cert and two CN-scoped client certs (`kape-adapter`, `kape-handler`) used by NATS for permission mapping.
- **NATS k8s manifest** (`examples/nats/nats.yaml`): single-replica NATS 2.10 JetStream StatefulSet with `verify_and_map: true` + authorization (`kape-adapter` publish-only, `kape-handler` subscribe+publish on `kape.events.>`).
- **Go shared helper** (`adapters/internal/nats/connect.go`): `Connect(url, name, certFile, keyFile, caFile)` wires TLS 1.3+ mTLS when the three paths are set, otherwise warns and connects plain (local dev fallback). Covered by 5 unit tests with in-memory ECDSA cert generation.
- **alertmanager adapter** (`adapters/cmd/alertmanager/main.go`): swaps the plain `natsgo.Connect` block for `natspkg.Connect` reading `NATS_TLS_CERT`/`NATS_TLS_KEY`/`NATS_TLS_CA`.
- **Python runtime** (`runtime/src/kape_runtime/consumer.py`): `_build_nats_tls_context()` returns an `ssl.SSLContext` (TLS 1.3 minimum) when the three env vars are set; `ConsumerLoop.run()` passes it via `tls=` to `nats.connect`. 3 new tests cover env-unset, partial-env, and full-env paths (with openssl-generated test certs).
- **operator** (`operator/infra/k8s/deployment.go`): every handler Deployment now mounts `kape-handler-cert` at `/etc/kape/nats-certs` and exports the three `NATS_TLS_*` env vars on the handler container. Asserted by a new `TestDeploymentAdapter_NATSCertWiring`.

## Deferred / out of scope
- **`adapters/cmd/audit/main.go`** is not wired up here. The spec explicitly notes: *"This issue (#81) MUST be implemented after #76. ... `adapters/cmd/audit/main.go` does not exist until issue #76 is merged."* The audit binary will pick up the same `natspkg.Connect` pattern when #76 lands; the helper is ready and waiting.
- **Adapter Deployment YAML** for `kape-alertmanager-adapter` / `kape-audit-adapter` — the repo does not currently ship k8s manifests for the adapters (only `docker-compose.dev.yml`). The volume/env wiring is documented in the spec for when those manifests are added.

## Test Plan
- [x] `cd adapters && go test ./internal/nats/...` — 5 new `TestBuildTLSConfig_*` / `TestConnect_*` tests pass; existing publisher tests unchanged (the JetStream integration test is skipped/fails on environments without podman socket, pre-existing).
- [x] `cd operator && go test ./infra/k8s/...` — 7 PASS including the new `TestDeploymentAdapter_NATSCertWiring`.
- [x] `cd runtime && conda run -n kape-runtime pytest tests/test_consumer_tls.py tests/test_consumer.py` — 11 PASS (3 new + 8 existing).
- [x] All 9 YAML manifests under `examples/certs/` and `examples/nats/` parse cleanly.
- [ ] **Manual kind smoke test** per spec §"Kind cluster smoke test (manual, pre-merge)" — not run here; recommend running before merge to confirm cert-manager issues certs and a plain `nats sub` is rejected.

## Acceptance Criteria status
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Plain `nats sub` rejected with TLS error | Pending kind smoke test |
| 2 | Client with non-kape-ca cert rejected | Pending kind smoke test |
| 3 | `kape-adapter` CN: publish allowed, subscribe denied | Pending kind smoke test |
| 4 | `kape-handler` CN: subscribe + publish allowed | Pending kind smoke test |
| 5 | Alertmanager adapter connects + publishes over mTLS | Code ready; pending integration test |
| 6 | Audit adapter mTLS | **Deferred — waits on #76** |
| 7 | Python runtime consumer connects + receives over mTLS | Code ready; pending integration test |
| 8 | Local-dev fallback (warning + plain connect when env unset) | ✅ covered by tests in Go + Python |
| 9 | cert-manager Certificates reach Ready=True | Pending kind smoke test |

## SBOM Summary
| Module | Components | Flagged |
|---|---|---|
| adapters | N/A | none |
| operator | N/A | none |
| task-service | N/A | none |
| kapeproxy | FAILED: go.work requires go>=1.25.10 (env GOTOOLCHAIN=local blocks toolchain fetch) | N/A |

Generated via Snyk MCP `snyk_sca_scan` — 2026-05-17T17:30:00Z.

*Note:* The `kape-io` CLAUDE.md references a Snyk MCP tool that generates CycloneDX SBOMs per module; the current MCP surface only exposes `snyk_sbom_scan` (reads an existing SBOM) and `snyk_sca_scan` (vuln scan, no component count). This PR uses `snyk_sca_scan` as the closest substitute; "Components" is reported as N/A because the SCA tool does not return component counts. Three modules scanned clean (0 vulns); `kapeproxy` failed due to the same `GOTOOLCHAIN=local` issue affecting local `go build` — the toolchain pin in `go.work` (1.25.10) exceeds the locally installed go (1.25.9). Re-run with `GOTOOLCHAIN=auto` to fetch the pinned toolchain.