### PR TITLE
chore: gitignore root-level alertmanager + sweep stray build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ sbom/
 
 # Compiled binaries
 task-service/task-service
+/alertmanager
 
 # ignore binary build
 cmd
@@ -43,6 +44,14 @@ operator/cmd/cmd
 
 examples/sre-alertmanager/src/mock-api/mock-api
 examples/sre-alertmanager/src/mock-webhook/mock-webhook
+
+# Go test binaries and coverage artifacts
+*.test
+coverage.out
+*.prof
+
+# macOS
+.DS_Store
 
 # Playground
 kubeconfig.playground


### PR DESCRIPTION
## Summary

- No committed binaries found — audit of all 439 tracked files confirmed zero ELF/Mach-O/PE32 objects
- Added `/alertmanager` rule mirroring the existing `/cmd` pattern for the root-level alertmanager binary (~23 MB untracked)
- Added `*.test` to ignore Go test binaries produced by `go test -c`
- Added `coverage.out` and `*.prof` for Go coverage/profile artifacts
- Added `.DS_Store` for macOS metadata files

## Why

Untracked compiled artifacts (`alertmanager`, `cmd`) kept surfacing in `git status`, creating noise and risk of accidental commits. `/cmd` was already covered; `/alertmanager` was the gap. The additional entries (`*.test`, `coverage.out`, `*.prof`, `.DS_Store`) close other common gaps following the same conservative pattern already in the file.

## Test plan

- [ ] `git check-ignore -v -- alertmanager` → `.gitignore:34:/alertmanager  alertmanager`
- [ ] `git check-ignore -v -- foo.test` → matches `*.test` rule
- [ ] `git check-ignore -v -- coverage.out` → matches `coverage.out` rule
- [ ] `git check-ignore -v -- .DS_Store` → matches `.DS_Store` rule
- [ ] `git status` in a checkout with local build artifacts shows none of the above as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)