### PR TITLE
docs: align README/CONTRIBUTING Go version with go.work (1.25)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Welcome! KAPE is an early-stage project; contributions in any form — bug repor
 
 | Tool | Version | Notes |
 |---|---|---|
-| Go | 1.24+ | Workspace modules under `go.work` |
+| Go | 1.25+ | Workspace modules under `go.work` |
 | [golangci-lint](https://golangci-lint.run/) | latest | Go linting |
 | [controller-gen](https://github.com/kubernetes-sigs/controller-tools) | latest | CRD/RBAC code generation |
 | Python | 3.12+ | `runtime/` only; managed via [uv](https://docs.astral.sh/uv/) |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Autonomous cluster monitoring, reasoning, and remediation — declared entirely in Kubernetes CRDs.
 
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue)
-![Go](https://img.shields.io/badge/go-1.23-00ADD8)
+![Go](https://img.shields.io/badge/go-1.25-00ADD8)
 ![Python](https://img.shields.io/badge/python-3.12-3776AB)
 
 ## Why KAPE?


### PR DESCRIPTION
## Summary

- `README.md`: Go badge `1.23` → `1.25`
- `CONTRIBUTING.md`: tooling table `Go | 1.24+` → `Go | 1.25+`

## Why

Source of truth for the project's Go version is `go.work` (`go 1.25.10`, `toolchain go1.25.10`). README and CONTRIBUTING had drifted to older minor versions, so contributors landed with mismatched expectations.

Used minor-version form (`1.25+`) rather than pinning the patch so future patch bumps don't re-create the same drift.

## Test plan

- [x] `rg -nU 'Go ?1\.(2[0-4]|1[0-9])' README.md CONTRIBUTING.md` — no remaining outdated references
- [x] Both files mention `1.25` or `1.25+`

> Note: SBOM summary comment per project CLAUDE.md PR checklist will be posted as a follow-up — main session hit org Anthropic quota mid-flight. Docs-only PR; dependency footprint unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)