### PR TITLE
chore(makefile): stub dashboard build as no-op (WIP)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,22 @@ npm test -- --passWithNoTests
 npm run lint
 ```
 
+---
+
+## Dashboard build status (WIP)
+
+The dashboard build step in `make build` is currently a **no-op stub**.
+
+- Running `make build` (or `make build-dashboard`) prints a notice and exits 0 — it does **not** invoke `npm run build`.
+- The React Router scaffold under `dashboard/app/` is not yet production-buildable; wiring up a real build would block all contributors on a missing `node_modules` tree and a scaffold that doesn't compile cleanly.
+- To attempt the dashboard build manually (may not succeed yet):
+  ```bash
+  cd dashboard && npm install && npm run build
+  ```
+- This will be wired up as a proper build step when the dashboard slice lands. The work is tracked separately — watch the issue tracker for the relevant issue.
+
+---
+
 ### Container images (podman)
 
 The `Makefile` targets use `docker build` — substitute `podman build` locally:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: generate build test lint build-images docker-build podman-build playground-up playground-down playground-operator playground-logs fire-adapter clean help
+.PHONY: generate build build-dashboard test lint build-images docker-build podman-build playground-up playground-down playground-operator playground-logs fire-adapter clean help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
@@ -16,7 +16,10 @@ build: ## Build all Go binaries, Python wheel, and dashboard
 	go build ./task-service/cmd/...
 	go build ./adapters/cmd/...
 	cd runtime && uv build
-	cd dashboard && npm run build
+	$(MAKE) build-dashboard
+
+build-dashboard: ## (WIP) Stub for dashboard build — see docs
+	@echo "[WIP] dashboard build is a no-op stub — see CONTRIBUTING.md (Dashboard build status)"
 
 test: ## Run all tests (Go, Python, dashboard)
 	go test ./operator/...


### PR DESCRIPTION
## Summary

- Extract `build-dashboard` as a separate Makefile target; add to `.PHONY`
- The new target is a **no-op stub** that prints a WIP notice and exits 0
- `make build` now calls `$(MAKE) build-dashboard` instead of `cd dashboard && npm run build`
- Add "Dashboard build status (WIP)" section to CONTRIBUTING.md documenting the stub + manual opt-in path

## Why

`make build` was failing on every fresh checkout because the dashboard step ran `cd dashboard && npm run build` (which is `react-router build`), but the repo ships no `package-lock.json` and the React Router scaffold under `dashboard/app/` is not yet production-buildable. Honestly marking it WIP unblocks contributors and CI without pretending the build works.

The Go build lines and runtime build line are untouched — those are owned by the sibling Go-version PR (`fix/makefile-go-consistency`).

## Test plan

- [x] `make -n build` prints the new `$(MAKE) build-dashboard` line, no `npm run build`
- [x] `make build-dashboard` prints `[WIP] dashboard build is a no-op stub …` and exits 0
- [x] `make help` lists the new `build-dashboard` target

> Note: SBOM summary comment per project CLAUDE.md PR checklist will be posted as a follow-up — main session hit org Anthropic quota mid-flight. Build-system-only PR; dependency footprint unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)