### PR TITLE
chore: add memsearch.toml config to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,3 @@ kubeconfig.playground
 playground/.env
 playground/runtime/settings.toml
 .claude/standups/
-.memsearch.toml

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ kubeconfig.playground
 playground/.env
 playground/runtime/settings.toml
 .claude/standups/
+.memsearch.toml

--- a/.memsearch.toml
+++ b/.memsearch.toml
@@ -1,0 +1,7 @@
+collection = "kape_io"
+paths = ["docs/", "CONTEXT.md", "kapeproxy/", "operator/", "task-service/", "adapters/"]
+
+[embedding]
+provider = "ollama"
+model = "nomic-embed-text-v2-moe"
+base_url = "http://localhost:11434"


### PR DESCRIPTION
## Summary
- Add `.memsearch.toml` with ollama/nomic-embed-text-v2-moe embedding provider, indexing `docs/`, `CONTEXT.md`, `kapeproxy/`, `operator/`, `task-service/`, `adapters/`

## Test plan
- [x] `memsearch index` succeeded (1550 chunks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)