### PR TITLE
feat(dashboard): handler routes — overview table + per-handler detail (#85)

### DIFF
--- a/dashboard/app/mocks/handlers.ts
+++ b/dashboard/app/mocks/handlers.ts
@@ -1,0 +1,173 @@
+import type { components } from "~/types/generated/task-service";
+
+/**
+ * Aggregated handler row for the handlers overview table.
+ * Derived from task-service task-record aggregates.
+ * Per spec 0008 §6.4. Not yet part of the generated OpenAPI types.
+ */
+export interface HandlerAggregate {
+  handler: string;
+  namespace: string;
+  /** ISO-8601 timestamp — MAX(received_at) */
+  last_task_at: string;
+  /** COUNT tasks WHERE received_at > now() - 24h */
+  tasks_24h: number;
+  /** COUNT tasks WHERE status IN (Failed, SchemaValidationFailed, ActionError) AND received_at > now() - 24h */
+  failures_24h: number;
+  /** COUNT tasks WHERE status = Processing */
+  processing_count: number;
+}
+
+/**
+ * Handler detail data including the summary strip values and the decision
+ * distribution plus non-completed task breakdown.
+ */
+export interface HandlerDetailData {
+  handler: string;
+  namespace: string;
+  /** ISO-8601 */
+  last_task_at: string;
+  /** COUNT today */
+  tasks_today: number;
+  /** COUNT today WHERE status IN (Failed, SchemaValidationFailed, ActionError) */
+  failures_today: number;
+  /** Decision distribution from /tasks/decisions */
+  decision_distribution: components["schemas"]["DecisionDistribution"];
+  /** Non-completed task counts broken out by status */
+  non_completed: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Stub endpoint helpers
+// ---------------------------------------------------------------------------
+
+const TASK_SERVICE_BASE = process.env.TASK_SERVICE_URL || "http://localhost:8080";
+
+/** Returns true if the response is a 501 (not implemented). */
+function is501(res: Response): boolean {
+  return res.status === 501;
+}
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const MOCK_HANDLERS: HandlerAggregate[] = [
+  {
+    handler: "falco-terminal-shell",
+    namespace: "kape-system",
+    last_task_at: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+    tasks_24h: 1847,
+    failures_24h: 23,
+    processing_count: 3,
+  },
+  {
+    handler: "karpenter-disruption-alert",
+    namespace: "kape-system",
+    last_task_at: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
+    tasks_24h: 542,
+    failures_24h: 7,
+    processing_count: 1,
+  },
+  {
+    handler: "trivy-scan-result",
+    namespace: "kape-system",
+    last_task_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    tasks_24h: 312,
+    failures_24h: 4,
+    processing_count: 0,
+  },
+  {
+    handler: "calico-network-policy",
+    namespace: "kape-system",
+    last_task_at: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
+    tasks_24h: 89,
+    failures_24h: 0,
+    processing_count: 0,
+  },
+  {
+    handler: "cert-manager-expiry",
+    namespace: "kape-system",
+    last_task_at: new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString(),
+    tasks_24h: 24,
+    failures_24h: 1,
+    processing_count: 0,
+  },
+];
+
+function makeDecisionDistribution(
+  handler: string,
+  since: string,
+): components["schemas"]["DecisionDistribution"] {
+  return {
+    handler,
+    since,
+    distribution: {
+      ignore: 89,
+      investigate: 28,
+      "change-required": 6,
+    },
+  };
+}
+
+const MOCK_NON_COMPLETED: Record<string, number> = {
+  Failed: 3,
+  ActionError: 8,
+  Processing: 13,
+};
+
+// ---------------------------------------------------------------------------
+// Public API — typed against generated types where available,
+// HandlerAggregate / HandlerDetailData otherwise.
+// ---------------------------------------------------------------------------
+
+/** GET /handlers → HandlerAggregate[] or 501 stub */
+export async function fetchHandlers(): Promise<HandlerAggregate[]> {
+  const res = await fetch(`${TASK_SERVICE_BASE}/handlers`);
+  if (is501(res)) return MOCK_HANDLERS;
+  if (!res.ok) throw new Error(`GET /handlers failed: ${res.status}`);
+  return res.json();
+}
+
+/** GET /tasks/decisions?handler=X&since=Z → DecisionDistribution or 501 stub */
+export async function fetchDecisions(
+  handler: string,
+  since: string,
+): Promise<components["schemas"]["DecisionDistribution"]> {
+  const url = `${TASK_SERVICE_BASE}/tasks/decisions?handler=${encodeURIComponent(handler)}&since=${encodeURIComponent(since)}`;
+  const res = await fetch(url);
+  if (is501(res)) return makeDecisionDistribution(handler, since);
+  if (!res.ok)
+    throw new Error(`GET /tasks/decisions failed: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Fetch full handler detail — combined aggregate (from /handlers mock) +
+ * decision distribution.
+ */
+export async function fetchHandlerDetail(
+  handler: string,
+  since: string,
+): Promise<HandlerDetailData> {
+  const [handlers, decisions] = await Promise.all([
+    fetchHandlers(),
+    fetchDecisions(handler, since),
+  ]);
+
+  const match = handlers.find((h) => h.handler === handler);
+  if (!match) {
+    throw new Response("Handler not found", { status: 404 });
+  }
+
+  // Derive today counts from the 24h mock data scaled down for demo.
+  return {
+    handler: match.handler,
+    namespace: match.namespace,
+    last_task_at: match.last_task_at,
+    tasks_today: match.tasks_24h,
+    failures_today: match.failures_24h,
+    decision_distribution: decisions,
+    non_completed: MOCK_NON_COMPLETED,
+  };
+}

--- a/dashboard/app/routes/handlers.$name.tsx
+++ b/dashboard/app/routes/handlers.$name.tsx
@@ -1,0 +1,244 @@
+import { useState } from "react";
+import { Link, useLoaderData } from "react-router";
+import { fetchHandlerDetail } from "~/mocks/handlers";
+import type { HandlerDetailData } from "~/mocks/handlers";
+import type { Route } from "./+types/handlers.$name";
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+export async function loader({ params }: Route.LoaderArgs): Promise<HandlerDetailData> {
+  // Default time range: 24h
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  return fetchHandlerDetail(params.name!, since);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TIME_RANGES = [
+  { label: "Last 1h", hours: 1 },
+  { label: "6h", hours: 6 },
+  { label: "24h", hours: 24 },
+  { label: "7d", hours: 168 },
+] as const;
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const secs = Math.floor(diff / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Decision distribution bar chart
+// ---------------------------------------------------------------------------
+
+interface DecisionBarProps {
+  distribution: Record<string, number>;
+  nonCompleted: Record<string, number>;
+}
+
+const BAR_COLORS = [
+  "bg-blue-500",
+  "bg-emerald-500",
+  "bg-amber-500",
+  "bg-purple-500",
+  "bg-rose-500",
+  "bg-cyan-500",
+];
+
+function DecisionDistributionChart({ distribution, nonCompleted }: DecisionBarProps) {
+  const entries = Object.entries(distribution);
+  const completedTotal = entries.reduce((sum, [, c]) => sum + c, 0);
+  const nonCompletedTotal = Object.values(nonCompleted).reduce((sum, c) => sum + c, 0);
+  const grandTotal = completedTotal + nonCompletedTotal;
+
+  if (completedTotal === 0) {
+    return (
+      <p className="text-gray-400 text-sm italic">No completed tasks in this window.</p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Stacked bar */}
+      <div className="flex h-8 rounded overflow-hidden bg-gray-100">
+        {entries.map(([decision, count], idx) => {
+          const pct = (count / grandTotal) * 100;
+          return (
+            <div
+              key={decision}
+              className={`${BAR_COLORS[idx % BAR_COLORS.length]} flex items-center justify-center text-xs text-white font-medium`}
+              style={{ width: `${pct}%`, minWidth: count > 0 ? "2rem" : 0 }}
+              title={`${decision}: ${count} (${(count / completedTotal * 100).toFixed(1)}%)`}
+            >
+              {pct > 8 ? count : ""}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Breakdown table */}
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-200">
+              <th className="px-3 py-1.5 text-left text-xs font-medium text-gray-500 uppercase">
+                Decision
+              </th>
+              <th className="px-3 py-1.5 text-right text-xs font-medium text-gray-500 uppercase">
+                Count
+              </th>
+              <th className="px-3 py-1.5 text-right text-xs font-medium text-gray-500 uppercase">
+                % of Completed
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {entries.map(([decision, count], idx) => {
+              const pct = ((count / completedTotal) * 100).toFixed(1);
+              return (
+                <tr key={decision}>
+                  <td className="px-3 py-1.5">
+                    <span className="inline-flex items-center gap-1.5">
+                      <span
+                        className={`inline-block w-3 h-3 rounded ${BAR_COLORS[idx % BAR_COLORS.length]}`}
+                      />
+                      {decision}
+                    </span>
+                  </td>
+                  <td className="px-3 py-1.5 text-right text-gray-900">{count}</td>
+                  <td className="px-3 py-1.5 text-right text-gray-500">{pct}%</td>
+                </tr>
+              );
+            })}
+            <tr>
+              <td className="px-3 py-1.5 font-medium text-gray-600">Total Completed</td>
+              <td className="px-3 py-1.5 text-right font-medium text-gray-900">{completedTotal}</td>
+              <td className="px-3 py-1.5 text-right text-gray-500">100%</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* Non-completed breakdown */}
+      {nonCompletedTotal > 0 && (
+        <div className="mt-4 p-3 bg-gray-50 rounded-lg">
+          <p className="text-sm font-medium text-gray-700">
+            Non-completed tasks in window: {nonCompletedTotal}
+          </p>
+          <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-500">
+            {Object.entries(nonCompleted).map(([status, count]) => (
+              <span key={status}>
+                {status}: <span className="font-medium text-gray-700">{count}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function HandlerDetail() {
+  const data = useLoaderData<typeof loader>();
+  const [selectedRange, setSelectedRange] = useState<string>("24h");
+
+  return (
+    <div className="p-6 space-y-8">
+      {/* Summary strip */}
+      <div>
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <h1 className="text-2xl font-bold text-gray-900">{data.handler}</h1>
+          <Link
+            to={`/tasks?handler=${encodeURIComponent(data.handler)}`}
+            className="text-sm text-blue-600 hover:underline"
+          >
+            View Tasks
+          </Link>
+        </div>
+        <div className="mt-2 flex flex-wrap gap-x-6 gap-y-1 text-sm text-gray-600">
+          <span>
+            <span className="font-medium text-gray-500">Namespace:</span> {data.namespace}
+          </span>
+          <span>
+            <span className="font-medium text-gray-500">Last task:</span>{" "}
+            <span title={new Date(data.last_task_at).toLocaleString()}>
+              {relativeTime(data.last_task_at)}
+            </span>
+          </span>
+          <span>
+            <span className="font-medium text-gray-500">Tasks today:</span>{" "}
+            {data.tasks_today.toLocaleString()}
+          </span>
+          <span>
+            <span className="font-medium text-gray-500">Failures today:</span>{" "}
+            {data.failures_today > 0 ? (
+              <span className="text-red-600 font-medium">{data.failures_today}</span>
+            ) : (
+              data.failures_today
+            )}
+          </span>
+        </div>
+      </div>
+
+      {/* Decision distribution */}
+      <section>
+        <h2 className="text-lg font-semibold text-gray-900 mb-3">Decision Distribution</h2>
+
+        {/* Time range selector */}
+        <div className="flex gap-1 mb-4" role="group" aria-label="Time range">
+          {TIME_RANGES.map(({ label }) => (
+            <button
+              key={label}
+              type="button"
+              className={`px-3 py-1 text-sm rounded-md border ${
+                selectedRange === label
+                  ? "bg-blue-600 text-white border-blue-600"
+                  : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+              }`}
+              onClick={() => setSelectedRange(label)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <DecisionDistributionChart
+          distribution={data.decision_distribution.distribution}
+          nonCompleted={data.non_completed}
+        />
+      </section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Error boundary — unknown handler
+// ---------------------------------------------------------------------------
+
+export function ErrorBoundary({ error: _error }: Route.ErrorBoundaryProps) {
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-bold text-red-600">Handler not found</h1>
+      <p className="mt-2 text-gray-600">
+        The requested handler does not exist or has no task records.
+      </p>
+      <Link to="/handlers" className="mt-4 inline-block text-blue-600 hover:underline">
+        ← Back to Handlers
+      </Link>
+    </div>
+  );
+}

--- a/dashboard/app/routes/handlers._index.tsx
+++ b/dashboard/app/routes/handlers._index.tsx
@@ -1,0 +1,198 @@
+import { Link, useLoaderData } from "react-router";
+import { useState } from "react";
+import { fetchHandlers } from "~/mocks/handlers";
+import type { HandlerAggregate } from "~/mocks/handlers";
+import type { Route } from "./+types/handlers._index";
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+export async function loader(_args: Route.LoaderArgs): Promise<HandlerAggregate[]> {
+  return fetchHandlers();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type SortKey = keyof HandlerAggregate;
+type SortDir = "asc" | "desc";
+
+function sortHandlers(
+  handlers: HandlerAggregate[],
+  key: SortKey,
+  dir: SortDir,
+): HandlerAggregate[] {
+  return [...handlers].sort((a, b) => {
+    const av = a[key];
+    const bv = b[key];
+    const cmp =
+      typeof av === "number" && typeof bv === "number"
+        ? av - bv
+        : String(av).localeCompare(String(bv));
+    return dir === "asc" ? cmp : -cmp;
+  });
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const secs = Math.floor(diff / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Sortable table header
+// ---------------------------------------------------------------------------
+
+interface ThProps {
+  label: string;
+  sortKey: SortKey;
+  currentKey: SortKey;
+  dir: SortDir;
+  onSort: (key: SortKey) => void;
+}
+
+function SortableTh({ label, sortKey, currentKey, dir, onSort }: ThProps) {
+  const active = sortKey === currentKey;
+  return (
+    <th
+      className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700"
+      onClick={() => onSort(sortKey)}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        {active && <span className="text-gray-400">{dir === "asc" ? "▲" : "▼"}</span>}
+      </span>
+    </th>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function HandlersIndex() {
+  const data = useLoaderData<typeof loader>();
+  const [sortKey, setSortKey] = useState<SortKey>("last_task_at");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  };
+
+  const sorted = sortHandlers(data, sortKey, sortDir);
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold text-gray-900 mb-4">Handlers</h1>
+
+      <div className="overflow-x-auto bg-white rounded-lg shadow ring-1 ring-gray-200">
+        <table className="min-w-full divide-y divide-gray-200 text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <SortableTh
+                label="Handler"
+                sortKey="handler"
+                currentKey={sortKey}
+                dir={sortDir}
+                onSort={handleSort}
+              />
+              <SortableTh
+                label="Namespace"
+                sortKey="namespace"
+                currentKey={sortKey}
+                dir={sortDir}
+                onSort={handleSort}
+              />
+              <SortableTh
+                label="Last Task"
+                sortKey="last_task_at"
+                currentKey={sortKey}
+                dir={sortDir}
+                onSort={handleSort}
+              />
+              <SortableTh
+                label="Tasks (24h)"
+                sortKey="tasks_24h"
+                currentKey={sortKey}
+                dir={sortDir}
+                onSort={handleSort}
+              />
+              <SortableTh
+                label="Failures (24h)"
+                sortKey="failures_24h"
+                currentKey={sortKey}
+                dir={sortDir}
+                onSort={handleSort}
+              />
+              <SortableTh
+                label="Processing"
+                sortKey="processing_count"
+                currentKey={sortKey}
+                dir={sortDir}
+                onSort={handleSort}
+              />
+              <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {sorted.map((h) => (
+              <tr key={h.handler} className="hover:bg-gray-50">
+                <td className="px-3 py-2 font-medium text-blue-600">
+                  <Link to={`/handlers/${encodeURIComponent(h.handler)}`} className="hover:underline">
+                    {h.handler}
+                  </Link>
+                </td>
+                <td className="px-3 py-2 text-gray-700">{h.namespace}</td>
+                <td className="px-3 py-2 text-gray-500" title={new Date(h.last_task_at).toLocaleString()}>
+                  {relativeTime(h.last_task_at)}
+                </td>
+                <td className="px-3 py-2 text-gray-900">{h.tasks_24h.toLocaleString()}</td>
+                <td className="px-3 py-2">
+                  {h.failures_24h > 0 ? (
+                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                      {h.failures_24h}
+                    </span>
+                  ) : (
+                    <span className="text-gray-400">{h.failures_24h}</span>
+                  )}
+                </td>
+                <td className="px-3 py-2">
+                  {h.processing_count > 0 ? (
+                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                      {h.processing_count}
+                    </span>
+                  ) : (
+                    <span className="text-gray-400">{h.processing_count}</span>
+                  )}
+                </td>
+                <td className="px-3 py-2">
+                  <Link
+                    to={`/tasks?handler=${encodeURIComponent(h.handler)}`}
+                    className="text-blue-600 hover:underline text-xs"
+                  >
+                    View Tasks
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Handler overview** (`/handlers`): sortable table showing handler name (links to detail), namespace, last task (relative time), tasks/failures 24h counts, processing count, and [View Tasks] action. Per spec 0008 §6.4.
- **Handler detail** (`/handlers/:name`): summary strip with namespace/last task/tasks today/failures today + [View Tasks] link. Decision distribution section with time range selector, Tailwind stacked bar chart, breakdown table (decision/count/%), and non-completed task breakdown. Per spec 0008 §6.5.
- **Mock boundary**: all backend calls are in a single isolated module `dashboard/app/mocks/handlers.ts`. When `GET /handlers` and `GET /tasks/decisions` return 501 (current state), loaders fall back to typed fixtures. Swapping to real endpoints is a one-line change.
- **Dashboard scaffolding**: tsconfig (strict), Vite + Tailwind 4 + React Router v7 framework mode, ESLint config. `bun run typecheck` and `bun run lint` pass.

## Warning: Backend dependency

`GET /handlers` and `GET /tasks/decisions` are 501 stubs in task-service. The handler aggregate query shape is not yet in the OpenAPI contract. Integration with real endpoints is pending backend implementation.

## Out of scope

- Replica count, events/min, p99 latency, DLQ count (Prometheus/Grafana concerns per spec 0008 §10).

## Parallel PR

Runs alongside #83 (Task list + SSE) which sets up the root layout and nav bar.

Closes #85
