### PR TITLE
fix: restore dashboard Docker build with workspace bun.lock (#131)

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,14 +1,15 @@
 FROM oven/bun:1.3.12-alpine AS builder
 WORKDIR /app
-COPY dashboard/package.json bun.lock ./
-RUN bun install --frozen-lockfile
-COPY dashboard/ .
-RUN bun run build
+COPY package.json bun.lock ./
+COPY dashboard/package.json ./dashboard/
+COPY dashboard/ ./dashboard/
+RUN cd dashboard && bun install --frozen-lockfile
+RUN cd dashboard && node_modules/.bin/react-router build
 
 FROM oven/bun:1.3.12-alpine
 WORKDIR /app
-COPY --from=builder /app/build ./build
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./
+COPY --from=builder /app/dashboard/build ./build
+COPY --from=builder /app/dashboard/node_modules ./node_modules
+COPY --from=builder /app/dashboard/package.json ./
 EXPOSE 3000
 CMD ["bun", "build/server/index.js"]

--- a/dashboard/app/components/status-badge.tsx
+++ b/dashboard/app/components/status-badge.tsx
@@ -1,0 +1,1 @@
+export { StatusBadge } from "./StatusBadge";

--- a/dashboard/app/routes.ts
+++ b/dashboard/app/routes.ts
@@ -1,0 +1,11 @@
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
+
+export default [
+  index("routes/_index.tsx"),
+  route("handlers", "routes/handlers._index.tsx"),
+  route("handlers/:name", "routes/handlers.$name.tsx"),
+  route("sse/tasks", "routes/sse.tasks.ts"),
+  route("tasks", "routes/tasks._index.tsx"),
+  route("tasks/:id", "routes/tasks.$id.tsx"),
+  route("tasks/:id/lineage", "routes/tasks.$id.lineage.tsx"),
+] satisfies RouteConfig;

--- a/dashboard/app/routes/tasks._index.tsx
+++ b/dashboard/app/routes/tasks._index.tsx
@@ -6,7 +6,6 @@ import {
   useNavigate,
   useRevalidator,
 } from "react-router";
-import { listTasks } from "~/lib/api.server";
 import type { Task, TaskList } from "~/lib/api.server";
 import { shortId, canTimeout, canRetry } from "~/lib/utils";
 import { StatusBadge } from "~/components/StatusBadge";
@@ -182,14 +181,15 @@ export default function TasksIndex() {
       const status = params.get("status") ?? undefined;
       const since = params.get("since") ?? undefined;
 
-      const data = await listTasks({
-        handler: handler ?? undefined,
-        status: status ?? undefined,
-        since: since ?? undefined,
-        sort: "received_at:desc",
-        limit: 50,
-        cursor: nextCursor,
-      });
+      const qs = new URLSearchParams();
+      if (handler) qs.set("handler", handler);
+      if (status) qs.set("status", status);
+      if (since) qs.set("since", since);
+      qs.set("sort", "received_at:desc");
+      qs.set("limit", "50");
+      qs.set("cursor", nextCursor);
+      const res = await fetch(`/tasks?${qs.toString()}`);
+      const { data } = (await res.json()) as { data: TaskList };
 
       // Merge into map (de-dup by ID)
       const map = taskMapRef.current;

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,7 +1,13 @@
 import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
+import { resolve } from "path";
 
 export default defineConfig({
   plugins: [tailwindcss(), reactRouter()],
+  resolve: {
+    alias: {
+      "~": resolve(__dirname, "app"),
+    },
+  },
 });


### PR DESCRIPTION
## Summary

- The Dockerfile was copying `dashboard/package.json` + `bun.lock` without the workspace root `package.json`, so bun had no workspace context and treated the workspace lockfile as standalone — causing `--frozen-lockfile` to fail with "lockfile had changes"
- Fixed by copying the workspace root `package.json` alongside `bun.lock` so bun correctly resolves the workspace structure
- Also fixes react-router@7.17.0 breaking changes that were already in the lockfile: adds required `app/routes.ts`, exposes the `~` path alias in vite config, adds a `status-badge.tsx` barrel for the case-sensitive import, and replaces the server-only `listTasks` call in the client-side `loadMore` callback with a fetch to the route loader

## Test plan

- [x] \`bun install --frozen-lockfile\` passes in the Docker build (no "lockfile had changes" error)
- [x] \`react-router build\` completes successfully inside Docker
- [x] Dashboard image builds end-to-end: \`make playground-up\` builds \`kape-playground-dashboard\` with no errors
- [x] \`make playground-down\` tears down cleanly

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)