### PR TITLE
docs: rewrite CLAUDE.md into five-section structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,70 @@
 # kape-io Project Instructions
 
-## Agent skills
+## What this is
 
-### Issue tracker
+KAPE (Kubernetes Agentic Platform Execution) is a Kubernetes-native, event-driven platform for running LLM agents. Platform engineers declare intent — prompts, guardrails, conditions — as `Kape*` custom resources; the operator materialises the infrastructure, and the Python/LangGraph runtime processes events inside Handler pods.
 
-Issues and PRDs live as GitHub issues on `dzungtr/kape` (use the `gh` CLI). See `docs/agents/issue-tracker.md`.
+Glossary: `CONTEXT.md`. Architecture decisions: `docs/adr/`.
 
-### Triage labels
+## Repo structure
 
-The kape-io label taxonomy adopts the five canonical Pocock triage roles directly: the triage state is a single-label enum (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`), and the agent-vs-human audience is a decided state set in `/triage`, not inferred from the assignee. See `docs/agents/triage-labels.md`, the decision in `docs/adr/0001-github-label-taxonomy.md`, and the operational contract in `docs/agent-rituals.md`.
+| Path | What it is | Toolchain |
+|---|---|---|
+| `operator/` | Kubernetes controller — watches Kape* CRDs, materialises Handler pods | Go (go.work) |
+| `task-service/` | Task tracking microservice | Go (go.work) |
+| `adapters/` | CloudEvents adapters (Falco, AlertManager, k8s Audit) | Go (go.work) |
+| `kapeproxy/` | MCP federation sidecar per Handler pod | Go (go.work) |
+| `runtime/` | LangGraph ReAct agent runtime | Python / uv / conda |
+| `dashboard/` | React frontend for task feed | TypeScript / bun |
+| `charts/` | Helm chart for cluster deployment | Helm |
+| `crds/` | Generated CRD manifests — **do not edit by hand** | controller-gen |
+| `config/` | Operator configuration | — |
+| `playground/` | Local dev stack (podman compose) | — |
+| `docs/` | Architecture docs, ADRs, CRD reference | — |
+| `examples/` | Reference KapeHandler/KapeTool/KapeSchema YAML | — |
 
-### Domain docs
+Deeper layout and prerequisites: `CONTRIBUTING.md`.
 
-Single-context: `CONTEXT.md` (glossary) and `docs/adr/` (decisions) at the repo root. See `docs/agents/domain.md`.
+## Build, test, run
+
+Entry points via `Makefile` from repo root:
+
+```
+make build      # all Go binaries, Python wheel, dashboard
+make test       # all tests (Go, Python, dashboard)
+make lint       # golangci-lint + ruff + ESLint
+make generate   # regenerate CRDs and TypeScript API types
+```
+
+Local stack: `make playground-up` (podman compose, copies example configs on first run).
+
+**Gotchas — wrong tool = broken environment:**
+
+- **Python tests:** `conda run -n kape-runtime pytest` (not plain pytest)
+- **Containers:** `podman` / `podman compose` — never `docker` / `docker compose`
+- **Dashboard:** `bun` — never `npm` or `yarn`
+- **Go tests:** require podman socket env (`DOCKER_HOST=unix://$(XDG_RUNTIME_DIR)/podman/podman.sock TESTCONTAINERS_RYUK_DISABLED=true`); `make test` sets this automatically
+
+Full prerequisites and per-module commands: `CONTRIBUTING.md`. `Makefile` is the source of truth for all build targets.
+
+## Backlog & issues
+
+Issues and PRDs live as GitHub issues on `dzungtr/kape` — use `gh` CLI for all issue operations.
+
+Full operational contract (label state machine, mutability table): `docs/agent-rituals.md`.  
+Pocock vocabulary bridge: `docs/agents/triage-labels.md`.  
+Taxonomy decision: `docs/adr/0001-github-label-taxonomy.md`.
+
+Rituals as skills: `/standup`, `/triage`, `/to-issues`, `/to-prd`, `/apply-labels`.
+
+## Domain docs
+
+Before exploring any area of the codebase, read `CONTEXT.md` (glossary) and the relevant `docs/adr/` files — see `docs/agents/domain.md`.
+
+**memsearch:** before starting a task, run:
+
+```
+memsearch search "<terms>" -c kape_io --top-k 5
+```
+
+or use `/memsearch-search`. Indexed sources: `docs/`, `CONTEXT.md`, Go modules (see `.memsearch.toml`). After editing docs, re-index with `/memsearch-index`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,12 @@ Rituals as skills: `/standup`, `/triage`, `/to-issues`, `/to-prd`, `/apply-label
 
 ## Domain docs
 
-Before exploring any area of the codebase, read `CONTEXT.md` (glossary) and the relevant `docs/adr/` files — see `docs/agents/domain.md`.
-
-**memsearch:** before starting a task, run:
+Before starting any task, run memsearch to orient:
 
 ```
 memsearch search "<terms>" -c kape_io --top-k 5
 ```
 
-or use `/memsearch-search`. Indexed sources: `docs/`, `CONTEXT.md`, Go modules (see `.memsearch.toml`). After editing docs, re-index with `/memsearch-index`.
+or `/memsearch-search`. Indexed sources: `docs/`, `CONTEXT.md`, Go modules (see `.memsearch.toml`). After editing docs, re-index with `/memsearch-index`.
+
+For deeper context on specific areas: `CONTEXT.md` (glossary) and `docs/adr/` — see `docs/agents/domain.md`.


### PR DESCRIPTION
## Summary

- Replaces the old stub (two agent-skills headers) with a five-section structure: **What this is**, **Repo structure**, **Build/test/run**, **Backlog & issues**, **Domain docs**
- Inlines the four high-frequency gotchas that cause wrong actions (podman not docker, conda env for Python tests, bun not npm, Go testcontainer socket env)
- Folds the old Issue-tracker and Triage-labels subsections into a single **Backlog & issues** section — pointers to `docs/agent-rituals.md`, `docs/agents/triage-labels.md`, and `docs/adr/0001` replace the duplicated inline content
- `crds/` is flagged do-not-edit-by-hand in the repo structure table

Closes #130

## Test plan

- [ ] CLAUDE.md has the five sections in order
- [ ] "What this is" is 2-3 sentences from CONTEXT.md + glossary/ADR pointer
- [ ] "Repo structure" table has one row per top-level component (~12), `crds/` flagged, pointer to CONTRIBUTING.md
- [ ] "Build, test, run" inlines the four gotchas + make entry commands + playground-up, points at CONTRIBUTING.md/Makefile
- [ ] "Backlog & issues" inlines only `dzungtr/kape` + `gh` fact and pointers; old subsections folded in with no standalone headers
- [ ] "Domain docs" covers read-CONTEXT/ADR-first and memsearch command with collection `kape_io`
- [ ] No content copied wholesale from CONTRIBUTING.md or agent-rituals.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)