### PR TITLE
refactor(metrics): replace kape_decisions_total with kape_action_results_total

### DIFF
--- a/docs/roadmap/phases/07-full-runtime/07-dedup-metrics.md
+++ b/docs/roadmap/phases/07-full-runtime/07-dedup-metrics.md
@@ -7,7 +7,7 @@
 
 ## Goal
 
-Add a sliding-window dedup cache to discard duplicate CloudEvent IDs within a 60-second window. Add Prometheus metrics for events, LLM latency, tool calls, and decisions.
+Add a sliding-window dedup cache to discard duplicate CloudEvent IDs within a 60-second window. Add Prometheus metrics for events, LLM latency, tool calls, and action results.
 
 ## Work
 
@@ -23,7 +23,7 @@ Add a sliding-window dedup cache to discard duplicate CloudEvent IDs within a 60
   - `kape_events_total` — Counter, labels: `handler`, `status` (`processed`, `deduplicated`, `failed`)
   - `kape_llm_latency_seconds` — Histogram, labels: `handler`
   - `kape_tool_calls_total` — Counter, labels: `handler`, `tool`
-  - `kape_decisions_total` — Counter, labels: `handler`, `decision`
+  - `kape_action_results_total` — Counter, labels: `handler`, `action`, `type`, `status` (`success`, `error`, `skipped`)
 - Expose via existing FastAPI `/metrics` endpoint in `probe.py` using `prometheus_client.generate_latest()`
 
 ## Acceptance Criteria

--- a/runtime/src/kape_runtime/actions/router.py
+++ b/runtime/src/kape_runtime/actions/router.py
@@ -9,6 +9,7 @@ from jsonpath_ng.ext import parse as jsonpath_parse
 from kape_runtime.actions.event_emitter import emit_event
 from kape_runtime.actions.save_memory import save_memory
 from kape_runtime.actions.webhook import post_webhook
+from kape_runtime.metrics import kape_action_results_total
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,11 @@ async def run_actions(
         action_type = action.get("type", "")
 
         if not _condition_matches(action.get("condition"), schema_output):
-            results.append({"name": name, "type": action_type, "status": "skipped"})
+            result = {"name": name, "type": action_type, "status": "skipped"}
+            results.append(result)
+            kape_action_results_total.labels(
+                handler=handler_name, action=name, type=action_type, status="skipped"
+            ).inc()
             continue
 
         try:
@@ -65,26 +70,33 @@ async def run_actions(
                     task_id=task_id,
                 )
             else:
-                results.append(
-                    {
-                        "name": name,
-                        "type": action_type,
-                        "status": "error",
-                        "error": f"unknown action type: {action_type!r}",
-                    }
-                )
-                continue
-
-            results.append({"name": name, "type": action_type, "status": "success"})
-        except Exception as exc:
-            logger.exception("Action %r (%s) failed", name, action_type)
-            results.append(
-                {
+                result = {
                     "name": name,
                     "type": action_type,
                     "status": "error",
-                    "error": str(exc),
+                    "error": f"unknown action type: {action_type!r}",
                 }
-            )
+                results.append(result)
+                kape_action_results_total.labels(
+                    handler=handler_name, action=name, type=action_type, status="error"
+                ).inc()
+                continue
+
+            results.append({"name": name, "type": action_type, "status": "success"})
+            kape_action_results_total.labels(
+                handler=handler_name, action=name, type=action_type, status="success"
+            ).inc()
+        except Exception as exc:
+            logger.exception("Action %r (%s) failed", name, action_type)
+            result = {
+                "name": name,
+                "type": action_type,
+                "status": "error",
+                "error": str(exc),
+            }
+            results.append(result)
+            kape_action_results_total.labels(
+                handler=handler_name, action=name, type=action_type, status="error"
+            ).inc()
 
     return results

--- a/runtime/src/kape_runtime/metrics.py
+++ b/runtime/src/kape_runtime/metrics.py
@@ -21,11 +21,8 @@ kape_tool_calls_total = Counter(
     labelnames=["handler", "tool"],
 )
 
-# Population deferred: KapeSchema is user-defined per handler, so the runtime cannot assume
-# a "decision" key exists in schema_output. A follow-up issue will introduce a
-# KapeHandler-level pointer (or KapeSchema annotation) naming the field to source from.
-kape_decisions_total = Counter(
-    "kape_decisions_total",
-    "Total schema-output decisions emitted by the runtime, partitioned by handler and decision.",
-    labelnames=["handler", "decision"],
+kape_action_results_total = Counter(
+    "kape_action_results_total",
+    "Total action results emitted by the runtime, partitioned by handler, action, type, and status.",
+    labelnames=["handler", "action", "type", "status"],
 )

--- a/runtime/tests/test_actions.py
+++ b/runtime/tests/test_actions.py
@@ -174,3 +174,158 @@ async def test_jsonpath_condition_false_skips_action():
 
     assert len(results) == 1
     assert results[0]["status"] == "skipped"
+
+
+
+
+@pytest.mark.asyncio
+async def test_action_result_metric_success(respx_mock):
+    from prometheus_client import REGISTRY
+
+    schema_output = {"value": 1}
+    action = {
+        "name": "my-webhook",
+        "type": "webhook",
+        "url": "http://example.test/ok",
+        "body_template": "{}",
+    }
+    respx_mock.post("http://example.test/ok").mock(return_value=httpx.Response(200))
+
+    await run_actions(
+        schema_output=schema_output,
+        actions=[action],
+        nats_client=None,
+        qdrant_client=None,
+        handler_name="test-handler",
+        task_id="t1",
+        parent_task_id="p1",
+    )
+
+    samples = {
+        (s.labels.get("handler"), s.labels.get("action"), s.labels.get("type"), s.labels.get("status")): s.value
+        for mf in REGISTRY.collect()
+        if mf.name == "kape_action_results"
+        for s in mf.samples
+        if s.name == "kape_action_results_total"
+    }
+    assert samples.get(("test-handler", "my-webhook", "webhook", "success"), 0) >= 1
+
+
+@pytest.mark.asyncio
+async def test_action_result_metric_error(respx_mock):
+    from prometheus_client import REGISTRY
+
+    schema_output = {"value": 1}
+    action = {
+        "name": "fail-webhook",
+        "type": "webhook",
+        "url": "http://example.test/fail",
+        "body_template": "{}",
+    }
+    respx_mock.post("http://example.test/fail").mock(return_value=httpx.Response(500, text="boom"))
+
+    await run_actions(
+        schema_output=schema_output,
+        actions=[action],
+        nats_client=None,
+        qdrant_client=None,
+        handler_name="test-handler",
+        task_id="t2",
+        parent_task_id="p2",
+    )
+
+    samples = {
+        (s.labels.get("handler"), s.labels.get("action"), s.labels.get("type"), s.labels.get("status")): s.value
+        for mf in REGISTRY.collect()
+        if mf.name == "kape_action_results"
+        for s in mf.samples
+        if s.name == "kape_action_results_total"
+    }
+    assert samples.get(("test-handler", "fail-webhook", "webhook", "error"), 0) >= 1
+
+
+@pytest.mark.asyncio
+async def test_action_result_metric_skipped():
+    from prometheus_client import REGISTRY
+
+    schema_output = {"decision": "ignore"}
+    action = {
+        "name": "skip-me",
+        "type": "webhook",
+        "condition": "$.decision[?(@ == 'change-required')]",
+        "url": "http://example.test/never",
+        "body_template": "{}",
+    }
+
+    await run_actions(
+        schema_output=schema_output,
+        actions=[action],
+        nats_client=None,
+        qdrant_client=None,
+        handler_name="test-handler",
+        task_id="t3",
+        parent_task_id="p3",
+    )
+
+    samples = {
+        (s.labels.get("handler"), s.labels.get("action"), s.labels.get("type"), s.labels.get("status")): s.value
+        for mf in REGISTRY.collect()
+        if mf.name == "kape_action_results"
+        for s in mf.samples
+        if s.name == "kape_action_results_total"
+    }
+    assert samples.get(("test-handler", "skip-me", "webhook", "skipped"), 0) >= 1
+
+
+@pytest.mark.asyncio
+async def test_multiple_actions_each_get_own_increment(respx_mock):
+    from prometheus_client import REGISTRY
+
+    schema_output = {"value": 1}
+    actions = [
+        {
+            "name": "action-a",
+            "type": "webhook",
+            "url": "http://example.test/a",
+            "body_template": "{}",
+        },
+        {
+            "name": "action-b",
+            "type": "webhook",
+            "url": "http://example.test/b",
+            "body_template": "{}",
+        },
+    ]
+    respx_mock.post("http://example.test/a").mock(return_value=httpx.Response(200))
+    respx_mock.post("http://example.test/b").mock(return_value=httpx.Response(200))
+
+    before = {
+        (s.labels.get("handler"), s.labels.get("action"), s.labels.get("type"), s.labels.get("status")): s.value
+        for mf in REGISTRY.collect()
+        if mf.name == "kape_action_results"
+        for s in mf.samples
+        if s.name == "kape_action_results_total"
+    }
+
+    await run_actions(
+        schema_output=schema_output,
+        actions=actions,
+        nats_client=None,
+        qdrant_client=None,
+        handler_name="multi-handler",
+        task_id="t4",
+        parent_task_id="p4",
+    )
+
+    after = {
+        (s.labels.get("handler"), s.labels.get("action"), s.labels.get("type"), s.labels.get("status")): s.value
+        for mf in REGISTRY.collect()
+        if mf.name == "kape_action_results"
+        for s in mf.samples
+        if s.name == "kape_action_results_total"
+    }
+
+    key_a = ("multi-handler", "action-a", "webhook", "success")
+    key_b = ("multi-handler", "action-b", "webhook", "success")
+    assert after.get(key_a, 0) - before.get(key_a, 0) == 1
+    assert after.get(key_b, 0) - before.get(key_b, 0) == 1

--- a/runtime/tests/test_probe.py
+++ b/runtime/tests/test_probe.py
@@ -45,4 +45,4 @@ async def test_metrics_endpoint_returns_prometheus_text():
     assert "kape_events_total" in body
     assert "kape_llm_latency_seconds" in body
     assert "kape_tool_calls_total" in body
-    assert "kape_decisions_total" in body
+    assert "kape_action_results_total" in body


### PR DESCRIPTION
## Summary

- Drops the always-zero `kape_decisions_total` counter (which silently no-oped because it attempted to read a `decision` field from schema output)
- Adds `kape_action_results_total{handler,action,type,status}` Counter wired directly to the actions router — incremented once per `ActionResult` using `name`, `type`, and `status` from each result dict
- Removes the deferred-population comment added by PR #21
- Updates `07-dedup-metrics.md` to reflect the renamed metric and new label set

## Test plan

- [x] `test_actions.py` — new tests for `success`, `error`, and `skipped` statuses each producing correct label values; multiple actions in one Task each get their own increment
- [x] `test_probe.py::test_metrics_endpoint_returns_prometheus_text` — asserts `kape_action_results_total` instead of `kape_decisions_total`
- [x] All 76 existing runtime tests pass with no regressions

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)